### PR TITLE
Deleted all trailing whitespace

### DIFF
--- a/gaphas/__init__.py
+++ b/gaphas/__init__.py
@@ -1,5 +1,5 @@
 """
-Gaphas 
+Gaphas
 ======
 
 Gaphor's Canvas.

--- a/gaphas/canvas.py
+++ b/gaphas/canvas.py
@@ -97,7 +97,7 @@ class Canvas(object):
         self._dirty_index = False
 
         self._registered_views = set()
-    
+
     solver = property(lambda s: s._solver)
 
 
@@ -370,7 +370,7 @@ class Canvas(object):
         # remove constraints to this item
         for cinfo in list(self._connections.query(connected=item)):
             disconnect_item(*cinfo)
-    
+
 
     @observed
     def reconnect_item(self, item, handle, constraint=None):
@@ -495,7 +495,7 @@ class Canvas(object):
                 connected=connected,
                 port=port)
 
-        
+
     def sort(self, items, reverse=False):
         """
         Sort a list of items in the order in which they are traversed in
@@ -553,12 +553,12 @@ class Canvas(object):
         except AttributeError:
             # Fall back to old behaviour
             return i2c * c2i
-        
+
 
     @observed
     def request_update(self, item, update=True, matrix=True):
         """
-        Set an update request for the item. 
+        Set an update request for the item.
 
         >>> c = Canvas()
         >>> from gaphas import item
@@ -808,7 +808,7 @@ class Canvas(object):
         for item in items:
             if item.normalize():
                 dirty_matrix_items.add(item)
-                
+
         return dirty_matrix_items
 
 
@@ -921,7 +921,7 @@ class VariableProjection(solver.Projection):
 
     The value has been set in the "other" coordinate system. A callback is
     executed when the value changes.
-    
+
     It's a simple Variable-like class, following the Projection protocol:
 
     >>> def notify_me(val):
@@ -1011,7 +1011,7 @@ class CanvasProjection(object):
         # Note: we can not use bound methods as callbacks, since that will
         #       cause pickle to fail.
         return self.pos[key]
-        
+
     def __iter__(self):
         return iter(self.pos)
 

--- a/gaphas/constraint.py
+++ b/gaphas/constraint.py
@@ -71,7 +71,7 @@ class Constraint(object):
         self.create_weakest_list()
 
         # Used by the Solver for efficiency
-        self._solver_has_projections = False 
+        self._solver_has_projections = False
 
 
     def create_weakest_list(self):
@@ -130,7 +130,7 @@ class Constraint(object):
         """
         wvar = self.weakest()
         self.solve_for(wvar)
-   
+
     def solve_for(self, var):
         """
         Solve the constraint for a given variable.
@@ -283,7 +283,7 @@ class EquationConstraint(Constraint):
 
     From: http://aspn.activestate.com/ASPN/Cookbook/Python/Recipe/303396
     """
-    
+
     def __init__(self, f, **args):
         super(EquationConstraint, self).__init__(*args.values())
         self._f = f
@@ -348,7 +348,7 @@ class EquationConstraint(Constraint):
         for nm, v in self._args.items():
             args[nm] = v.value
             if v is var: arg = nm
-        v = self._solve_for(arg, args) 
+        v = self._solve_for(arg, args)
         if var.value != v:
             var.value = v
 
@@ -507,7 +507,7 @@ class LineConstraint(Constraint):
         except ZeroDivisionError:
             self.ratio_y = 0.0
 
-        
+
     def solve_for(self, var=None):
         self._solve()
 
@@ -515,7 +515,7 @@ class LineConstraint(Constraint):
     def _solve(self):
         """
         Solve the equation for the connected_handle.
-        
+
         >>> from gaphas.solver import Variable
         >>> line = (Variable(0), Variable(0)), (Variable(30), Variable(20))
         >>> point = (Variable(15), Variable(4))
@@ -558,7 +558,7 @@ class PositionConstraint(Constraint):
         self._origin = origin
         self._point = point
 
-        
+
     def solve_for(self, var=None):
         """
         Ensure that point's coordinates are the same as coordinates of the
@@ -605,7 +605,7 @@ class LineAlignConstraint(Constraint):
         self._align = align
         self._delta = delta
 
-        
+
     def solve_for(self, var=None):
         sx, sy = self._line[0]
         ex, ey = self._line[1]

--- a/gaphas/decorators.py
+++ b/gaphas/decorators.py
@@ -34,12 +34,12 @@ class async(object):
     'Hi'
 
     Simple method:
-    
+
     >>> class A(object):
     ...     @async(single=False, priority=gobject.PRIORITY_HIGH)
     ...     def a(self):
     ...         print 'idle-a', gobject.main_depth()
-    
+
     Methods can also set single mode to True (the method is only scheduled one).
 
     >>> class B(object):

--- a/gaphas/examples.py
+++ b/gaphas/examples.py
@@ -36,8 +36,8 @@ class Box(Element):
 
 class PortoBox(Box):
     """
-    Box item with few falvours of port(o)s.
-    
+    Box item with few flavours of port(o)s.
+
     Default box ports are disabled. Three, non-default connectable ports
     are created (represented by ``x`` on the picture).
 

--- a/gaphas/freehand.py
+++ b/gaphas/freehand.py
@@ -4,7 +4,7 @@ Cairo context using Steve Hanov's freehand drawing code.
     # Crazyline. By Steve Hanov, 2008
     # Released to the public domain.
 
-    # The idea is to draw a curve, setting two control points at random 
+    # The idea is to draw a curve, setting two control points at random
     # close to each side of the line. The longer the line, the sloppier
     # it's drawn.
 
@@ -58,7 +58,7 @@ class FreeHandCairoContext(object):
         to_x = x + sloppiness * rand() * offset/4
         to_y = y + sloppiness * rand() * offset/4
 
-        # t1 and t2 are coordinates of a line shifted under or to the right of 
+        # t1 and t2 are coordinates of a line shifted under or to the right of
         # our original.
         t1_x = from_x + offset
         t1_y = from_y + offset
@@ -70,7 +70,7 @@ class FreeHandCairoContext(object):
         control1_x = t1_x + r * (t2_x-t1_x)
         control1_y = t1_y + r * (t2_y-t1_y)
 
-        # now make t1 and t2 the coordinates of our line shifted above 
+        # now make t1 and t2 the coordinates of our line shifted above
         # and to the left of the original.
 
         t1_x = from_x - offset
@@ -97,7 +97,7 @@ class FreeHandCairoContext(object):
 
         dev_x, dev_y = cr.user_to_device(x3, y3)
         rand = Random((from_x, from_y, dev_x, dev_y, x1, y1, x2, y2, x3, y3)).random
-        
+
         r = rand()
         c1_x = from_x + r * (x1-from_x)
         c1_y = from_y + r * (y1-from_y)
@@ -119,10 +119,10 @@ class FreeHandCairoContext(object):
         from_x, from_y = cr.get_current_point()
 
         # calculate radius of the circle.
-        radius1 = Math.sqrt( (cx-from_x)*(cx-from_x) + 
+        radius1 = Math.sqrt( (cx-from_x)*(cx-from_x) +
                 (cy-from_y)*(cy-from_y));
 
-        radius2 = Math.sqrt( (cx-x)*(cx-x) + 
+        radius2 = Math.sqrt( (cx-x)*(cx-x) +
                 (cy-y)*(cy-y));
 
         dev_x, dev_y = cr.user_to_device(x, y)
@@ -149,7 +149,7 @@ class FreeHandCairoContext(object):
             self.line_to(x, y)
         else:
             self.close_path()
-        
+
 
 class FreeHandPainter(object):
 

--- a/gaphas/geometry.py
+++ b/gaphas/geometry.py
@@ -63,7 +63,7 @@ class Rectangle(object):
         width = x1 - self.x
         if width < 0: width = 0
         self.width = width
-        
+
     x1 = property(lambda s: s.x + s.width, _set_x1)
 
     def _set_y1(self, y1):
@@ -86,7 +86,7 @@ class Rectangle(object):
         self.y -= delta
         self.width += delta * 2
         self.height += delta * 2
-        
+
     def __repr__(self):
         """
         >>> Rectangle(5,7,20,25)
@@ -119,7 +119,7 @@ class Rectangle(object):
         >>> if r: 'no'
         """
         return self.width > 0 and self.height > 0
-    
+
     def __eq__(self, other):
         return (type(self) is type(other)) \
                 and self.x == other.x \
@@ -311,7 +311,7 @@ def point_on_rectangle(rect, point, border=False):
     Return the point on which ``point`` can be projecten on the rectangle.
     ``border = True`` will make sure the point is bound to the border of
     the reactangle. Otherwise, if the point is in the rectangle, it's okay.
-    
+
     >>> point_on_rectangle(Rectangle(0, 0, 10, 10), (11, -1))
     (10, 0)
     >>> point_on_rectangle((0, 0, 10, 10), (5, 12))
@@ -375,7 +375,7 @@ def point_on_rectangle(rect, point, border=False):
 def distance_line_point(line_start, line_end, point):
     """
     Calculate the distance of a ``point`` from a line. The line is marked
-    by begin and end point ``line_start`` and ``line_end``. 
+    by begin and end point ``line_start`` and ``line_end``.
 
     A tuple is returned containing the distance and point on the line.
 
@@ -481,31 +481,31 @@ def intersect_line_line(line1_start, line1_end, line2_start, line2_end):
     #     In the following code, 'long' values have been used for this
     #     purpose, instead of 'int'.
     #
-   
+
     x1, y1 = line1_start
     x2, y2 = line1_end
     x3, y3 = line2_start
     x4, y4 = line2_end
-    
+
     #long a1, a2, b1, b2, c1, c2; /* Coefficients of line eqns. */
     #long r1, r2, r3, r4;         /* 'Sign' values */
     #long denom, offset, num;     /* Intermediate values */
 
     # Compute a1, b1, c1, where line joining points 1 and 2
     # is "a1 x  +  b1 y  +  c1  =  0".
-    
+
     a1 = y2 - y1
     b1 = x1 - x2
     c1 = x2 * y1 - x1 * y2
 
     # Compute r3 and r4.
-    
+
     r3 = a1 * x3 + b1 * y3 + c1
     r4 = a1 * x4 + b1 * y4 + c1
 
     # Check signs of r3 and r4.  If both point 3 and point 4 lie on
     # same side of line 1, the line segments do not intersect.
-    
+
     if r3 and r4 and (r3 * r4) >= 0:
         return None # ( DONT_INTERSECT )
 
@@ -523,12 +523,12 @@ def intersect_line_line(line1_start, line1_end, line2_start, line2_end):
     # Check signs of r1 and r2.  If both point 1 and point 2 lie
     # on same side of second line segment, the line segments do
     # not intersect.
-    
+
     if r1 and r2 and (r1 * r2) >= 0: #SAME_SIGNS( r1, r2 ))
         return None # ( DONT_INTERSECT )
 
-    # Line segments intersect: compute intersection point. 
-    
+    # Line segments intersect: compute intersection point.
+
     denom = a1 * b2 - a2 * b1
     if not denom:
         return None # ( COLLINEAR )
@@ -537,7 +537,7 @@ def intersect_line_line(line1_start, line1_end, line2_start, line2_end):
     # The denom/2 is to get rounding instead of truncating.  It
     # is added or subtracted to the numerator, depending upon the
     # sign of the numerator.
-    
+
     num = b1 * c2 - b2 * c1
     x = ( (num < 0) and (num - offset) or (num + offset) ) / denom
 

--- a/gaphas/guide.py
+++ b/gaphas/guide.py
@@ -211,7 +211,7 @@ class GuidedItemInMotion(GuideMixin, ItemInMotion):
 
         px, py = pos
         pdx, pdy = px - self.last_x, py - self.last_y
-        
+
         excluded_items = self.get_excluded_items()
 
         item_guide = Guide(item)
@@ -250,7 +250,7 @@ class GuidedItemHandleInMotion(GuideMixin, ItemHandleInMotion):
     def move(self, pos):
 
         sink = super(GuidedItemHandleInMotion, self).move(pos)
-        
+
         if not sink:
             item = self.item
             handle = self.handle
@@ -299,7 +299,7 @@ class GuidePainter(ItemPaintFocused):
             guides = self.view.guides
         except AttributeError:
             return
-        
+
         cr = context.cairo
         view = self.view
         allocation = view.allocation

--- a/gaphas/item.py
+++ b/gaphas/item.py
@@ -58,7 +58,7 @@ class Item(object):
         # used by gaphas.view.GtkView to hold item 2 view matrices (view=key)
         self._matrix_i2v = WeakKeyDictionary()
         self._matrix_v2i = WeakKeyDictionary()
-	self._canvas_projections = WeakSet()
+        self._canvas_projections = WeakSet()
 
     @observed
     def _set_canvas(self, canvas):
@@ -151,7 +151,7 @@ class Item(object):
         """
         Update handle positions of the item, so the first handle is always
         located at (0, 0).
-        
+
         Note that, since this method basically does some housekeeping during
         the update phase, there's no need to keep track of the changes.
 
@@ -192,7 +192,7 @@ class Item(object):
         """
         pass
 
-    
+
     def handles(self):
         """
         Return a list of handles owned by the item.
@@ -336,8 +336,8 @@ class Element(Item):
         # edge of element define default element ports
         self._ports = [
             LinePort(h_nw.pos, h_ne.pos),
-            LinePort(h_ne.pos, h_se.pos), 
-            LinePort(h_se.pos, h_sw.pos), 
+            LinePort(h_ne.pos, h_se.pos),
+            LinePort(h_se.pos, h_sw.pos),
             LinePort(h_sw.pos, h_nw.pos)
         ]
 
@@ -460,7 +460,7 @@ class Element(Item):
             for h in handles:
                 h.pos.y -= y
         return updated
-        
+
     def point(self, pos):
         """
         Distance from the point (x, y) to the item.
@@ -637,7 +637,7 @@ class Line(Item):
     def _create_handle(self, pos, strength=WEAK):
         return Handle(pos, strength=strength)
 
-    
+
     def _create_port(self, p1, p2):
         return LinePort(p1, p2)
 
@@ -680,7 +680,7 @@ class Line(Item):
     def closest_segment(self, pos):
         """
         Obtain a tuple (distance, point_on_line, segment).
-        Distance is the distance from point to the closest line segment 
+        Distance is the distance from point to the closest line segment
         Point_on_line is the reflection of the point on the line.
         Segment is the line segment closest to (x, y)
 

--- a/gaphas/matrix.py
+++ b/gaphas/matrix.py
@@ -94,7 +94,7 @@ class Matrix(object):
     @observed
     def __rmul__(self, other):
         return self._matrix.__rmul__(other)
- 
+
     def __repr__(self):
         return 'Matrix(%g, %g, %g, %g, %g, %g)' % tuple(self._matrix)
 

--- a/gaphas/painter.py
+++ b/gaphas/painter.py
@@ -87,7 +87,7 @@ class DrawContext(Context):
     """
 
     deprecated = False
-    
+
     def __init__(self, **kwargs):
         super(DrawContext, self).__init__(**kwargs)
 

--- a/gaphas/quadtree.py
+++ b/gaphas/quadtree.py
@@ -85,10 +85,10 @@ class Quadtree(object):
     def __init__(self, bounds=(0, 0, 0, 0), capacity=10):
         """
         Create a new Quadtree instance.
-        
+
         Bounds is the boundries of the quadtree. this is fixed and do not
         change depending on the contents.
-        
+
         Capacity defines the number of elements in one tree bucket (default: 10)
         """
         self._capacity = capacity
@@ -235,7 +235,7 @@ class Quadtree(object):
         Returns a set.
         """
         return set(self._bucket.find(rect, method=rectangle_contains))
-        
+
 
     def find_intersect(self, rect):
         """
@@ -244,7 +244,7 @@ class Quadtree(object):
         Returns a set.
         """
         return set(self._bucket.find(rect, method=rectangle_intersects))
-        
+
 
     def __len__(self):
         """
@@ -315,7 +315,7 @@ class QuadtreeBucket(object):
         The item should be contained by *this* bucket (not a sub-bucket).
         """
         del self.items[item]
-        
+
 
     def update(self, item, new_bounds):
         """
@@ -367,7 +367,7 @@ class QuadtreeBucket(object):
             for bucket in self._buckets:
                 for item in bucket.find(rect, method=method):
                     yield item
-                
+
 
     def clear(self):
         """

--- a/gaphas/segment.py
+++ b/gaphas/segment.py
@@ -50,7 +50,7 @@ class LineSegment(object):
          segment
             Segment number to split (starting from zero).
          count
-            Amount of new segments to be created (minimum 2). 
+            Amount of new segments to be created (minimum 2).
         """
         item = self.item
         if segment < 0 or segment >= len(item.ports()):
@@ -98,7 +98,7 @@ class LineSegment(object):
          segment
             Segment number to start merging from (starting from zero).
          count
-            Amount of segments to be merged (minimum 2). 
+            Amount of segments to be merged (minimum 2).
         """
         item = self.item
         if len(item.ports()) < 2:
@@ -159,7 +159,7 @@ class LineSegment(object):
         for cinfo in list(canvas.get_connections(connected=connected)):
             item, handle = cinfo.item, cinfo.handle
             port = find_port(item, handle, connected)
-            
+
             constraint = port.constraint(canvas, item, handle, connected)
 
             cinfo = canvas.get_connection(handle)

--- a/gaphas/solver.py
+++ b/gaphas/solver.py
@@ -57,7 +57,7 @@ class Variable(object):
     Representation of a variable in the constraint solver.
     Each Variable has a @value and a @strength. Ina constraint the
     weakest variables are changed.
-    
+
     You can even do some calculating with it. The Variable always represents
     a float variable.
     """
@@ -82,7 +82,7 @@ class Variable(object):
         """
         Mark the variable dirty in both the constraint solver and attached
         constraints.
-        
+
         Variables are marked dirty also during constraints solving to
         solve all dependent constraints, i.e. two equals constraints
         between 3 variables.
@@ -572,7 +572,7 @@ class Solver(object):
                     # All iteration have completed succesfully,
                     # so all variables are in the constraint
                     yield c
-                    
+
 
     def solve(self):
         """
@@ -639,9 +639,9 @@ class solvable(object):
     >>> a._v_x
     Variable(12, 20)
     >>> a.x = 3
-    >>> a.x 
+    >>> a.x
     Variable(3, 20)
-    >>> a.y 
+    >>> a.y
     Variable(0, 30)
     """
 

--- a/gaphas/state.py
+++ b/gaphas/state.py
@@ -32,7 +32,7 @@ from decorator import decorator
 DISPATCH_BY_DEFAULT = True
 
 # Add/remove methods from this subscribers list.
-# Subscribers should have signature method(event) where event is a 
+# Subscribers should have signature method(event) where event is a
 # Event has the form: (func, keywords)
 # Since most events originate from methods, it's save to call
 # saveapply(func, keywords) for those functions
@@ -68,7 +68,7 @@ def observed(func):
             if acquired:
                 mutex.release()
     dec = decorator(wrapper)(func)
-    
+
     func.__observer__ = dec
     return dec
 
@@ -133,7 +133,7 @@ def reversible_pair(func1, func2, bind1={}, bind2={}):
 def reversible_property(fget=None, fset=None, fdel=None, doc=None, bind={}):
     """
     Replacement for the property descriptor. In addition to creating a
-    property instance, the property is registered as reversible and 
+    property instance, the property is registered as reversible and
     reverse events can be send out when changes occur.
 
     Cave eat: we can't handle both fset and fdel in the proper way. Therefore
@@ -168,7 +168,7 @@ def revert_handler(event):
     First thing to do is to actually enable the revert_handler:
 
     >>> observers.add(revert_handler)
-    
+
     First let's define our simple list:
 
     >>> class SList(object):

--- a/gaphas/tests/test_canvas.py
+++ b/gaphas/tests/test_canvas.py
@@ -51,7 +51,7 @@ class CanvasTestCase(unittest.TestCase):
 
         c.connect_item(l, l.handles()[0], b1, b1.ports()[0])
         assert count(c.get_connections(handle=l.handles()[0])) == 1
-	
+
         # Add the same
         self.assertRaises(ConnectionError, c.connect_item, l, l.handles()[0], b1, b1.ports()[0])
         assert count(c.get_connections(handle=l.handles()[0])) == 1
@@ -79,7 +79,7 @@ class CanvasTestCase(unittest.TestCase):
 
         c.connect_item(l, l.handles()[0], b1, b1.ports()[0], callback=callback)
         assert count(c.get_connections(handle=l.handles()[0])) == 1
-	
+
         c.disconnect_item(l, l.handles()[0])
         assert count(c.get_connections(handle=l.handles()[0])) == 0
         assert events == ['called']
@@ -98,7 +98,7 @@ class CanvasTestCase(unittest.TestCase):
 
         c.connect_item(l, l.handles()[0], b1, b1.ports()[0], constraint=cons)
         assert count(c.get_connections(handle=l.handles()[0])) == 1
-	
+
         ncons = len(c.solver.constraints)
         assert ncons == 5
 
@@ -123,7 +123,7 @@ class CanvasTestCase(unittest.TestCase):
 
         c.connect_item(l, l.handles()[0], b1, b1.ports()[0], callback=callback)
         assert count(c.get_connections(handle=l.handles()[0])) == 1
-	
+
         c.remove(b1)
 
         assert count(c.get_connections(handle=l.handles()[0])) == 0
@@ -143,7 +143,7 @@ class CanvasTestCase(unittest.TestCase):
 
         c.connect_item(l, l.handles()[0], b1, b1.ports()[0], constraint=cons)
         assert count(c.get_connections(handle=l.handles()[0])) == 1
-	
+
         ncons = len(c.solver.constraints)
         assert ncons == 5
 
@@ -243,7 +243,7 @@ class CanvasConstraintTestCase(unittest.TestCase):
 
         # Expecting a class + line connected at one end only
         self.assertEquals(number_cons1 + 1, len(canvas.solver.constraints))
-        
+
 ###    def test_adding_constraint(self):
 ###        """Test adding canvas constraint"""
 ###        canvas = Canvas()

--- a/gaphas/tests/test_connector.py
+++ b/gaphas/tests/test_connector.py
@@ -21,17 +21,17 @@ class PositionTestCase(unittest.TestCase):
         y = Variable()
         assert x is not pos.x
         assert y is not pos.y
-        
+
         pos.set_x(x)
         pos.set_y(y)
         assert x is pos.x
         assert y is pos.y
-        
+
 class HandleTestCase(unittest.TestCase):
 
     def test_handle_x_y(self):
         h = Handle()
         self.assertEquals(0.0, h.x)
         self.assertEquals(0.0, h.y)
-        
+
 # vim: sw=4:et:ai

--- a/gaphas/tests/test_segment.py
+++ b/gaphas/tests/test_segment.py
@@ -100,7 +100,7 @@ class LineSplitTestCase(TestCaseBase):
         self.assertEquals(h2.pos, old_port.end)
 
         segment = Segment(self.line, self.view)
-        
+
         handles, ports = segment.split_segment(0)
         handle = handles[0]
         self.assertEquals(1, len(handles))
@@ -358,11 +358,11 @@ class LineMergeTestCase(TestCaseBase):
         self.line.handles()[1].pos = (20, 16)
         segment = Segment(self.line, self.view)
         segment.split_segment(0, count=3)
- 
+
         # start with 4 handles and 3 ports, merge 3 segments
         assert len(self.line.handles()) == 4
         assert len(self.line.ports()) == 3
- 
+
         print self.line.handles()
         handles, ports = segment.merge_segment(0, count=3)
         self.assertEquals(2, len(handles))
@@ -378,7 +378,7 @@ class LineMergeTestCase(TestCaseBase):
         self.assertEquals((0, 0), port.start.pos)
         self.assertEquals((20, 16), port.end.pos)
 
- 
+
     def test_merge_undo(self):
         """Test line merging undo
         """
@@ -393,18 +393,18 @@ class LineMergeTestCase(TestCaseBase):
 
         # clear undo stack before merging
         del undo_list[:]
- 
+
         # merge with empty undo stack
         segment.merge_segment(0)
         assert len(self.line.handles()) == 2
         assert len(self.line.ports()) == 1
- 
+
         # after merge undo, 3 handles and 2 ports are expected again
         undo()
         self.assertEquals(3, len(self.line.handles()))
         self.assertEquals(2, len(self.line.ports()))
- 
- 
+
+
     def test_orthogonal_line_merge(self):
         """Test orthogonal line merging
         """
@@ -429,7 +429,7 @@ class LineMergeTestCase(TestCaseBase):
         self.assertEquals(3, len(self.line.handles()))
         self.assertEquals(2, len(self.line.ports()))
 
- 
+
     def test_params_errors(self):
         """Test parameter error exceptions
         """
@@ -439,21 +439,21 @@ class LineMergeTestCase(TestCaseBase):
         segment.split_segment(0)
         # no segment -1
         self.assertRaises(ValueError, segment.merge_segment, -1)
- 
+
         line = Line()
         self.canvas.add(line)
         segment = Segment(line, self.view)
         segment.split_segment(0)
         # no segment no 2
         self.assertRaises(ValueError, segment.merge_segment, 2)
- 
+
         line = Line()
         self.canvas.add(line)
         segment = Segment(line, self.view)
         segment.split_segment(0)
         # can't merge one or less segments :)
         self.assertRaises(ValueError, segment.merge_segment, 0, 1)
- 
+
         line = Line()
         self.canvas.add(line)
         self.assertEquals(2, len(line.handles()))

--- a/gaphas/tests/test_tool.py
+++ b/gaphas/tests/test_tool.py
@@ -29,15 +29,15 @@ def simple_canvas(self):
     self.box1 = Box()
     self.canvas.add(self.box1)
     self.box1.matrix.translate(100, 50)
-    self.box1.width = 40 
-    self.box1.height = 40 
+    self.box1.width = 40
+    self.box1.height = 40
     self.box1.request_update()
 
     self.box2 = Box()
     self.canvas.add(self.box2)
     self.box2.matrix.translate(100, 150)
-    self.box2.width = 50 
-    self.box2.height = 50 
+    self.box2.width = 50
+    self.box2.height = 50
     self.box2.request_update()
 
     self.line = Line()
@@ -93,7 +93,7 @@ class ConnectHandleToolGlueTestCase(unittest.TestCase):
         sink = self.tool.glue(self.line, self.head, (100, 70))
         self.assertEquals(sink.item, self.box1)
         self.assertEquals(ports[3], sink.port)
-        
+
 
     def test_failed_glue(self):
         """Test glue from too far distance"""
@@ -115,7 +115,7 @@ class ConnectHandleToolGlueTestCase(unittest.TestCase):
 #            def __init__(self, *args):
 #                super(Tool, self).__init__(*args)
 #                self._calls = 0
-#                
+#
 #            def can_glue(self, *args):
 #                self._calls += 1
 #                return True

--- a/gaphas/tests/test_tree.py
+++ b/gaphas/tests/test_tree.py
@@ -67,7 +67,7 @@ class TreeTestCase(unittest.TestCase):
         tree.add(n3, index=1)
         assert tree.get_children(None) == [n1, n3, n2], tree.get_children(None)
         assert tree.nodes == [n1, n3, n2], tree.nodes
-        
+
         tree.add(n4, parent=n3)
         tree.add(n5, parent=n3, index=0)
         assert tree.get_children(None) == [n1, n3, n2], tree.get_children(None)
@@ -111,11 +111,11 @@ class TreeTestCase(unittest.TestCase):
         n1 = 'n1'
         n2 = 'n2'
         n3 = 'n3'
-        
+
         tree.add(n1)
         tree.add(n2)
         tree.add(n3)
-        
+
         assert tree.get_next_sibling(n1) is n2
         assert tree.get_next_sibling(n2) is n3
         try:

--- a/gaphas/tests/test_undo.py
+++ b/gaphas/tests/test_undo.py
@@ -36,7 +36,7 @@ class UndoTestCase(unittest.TestCase):
     def shutDown(self):
         state.observers.remove(state.revert_handler)
         state.subscribers.remove(undo_handler)
-    
+
     def testUndoOnDeletedElement(self):
         b1 = Box()
 
@@ -49,7 +49,7 @@ class UndoTestCase(unittest.TestCase):
 
         canvas.add(b2)
         self.assertEquals(4, len(canvas.solver.constraints))
-        
+
         canvas.add(line)
 
         sink = ConnectionSink(b1, b1.ports()[0])
@@ -62,7 +62,7 @@ class UndoTestCase(unittest.TestCase):
 
         self.assertEquals(6, len(canvas.solver.constraints))
         self.assertEquals(2, len(list(canvas.get_connections(item=line))))
-        
+
         del undo_list[:]
 
         # Here disconnect is not invoked!
@@ -93,7 +93,7 @@ class UndoTestCase(unittest.TestCase):
 
 #        self.assertEquals(list(canvas.solver.constraints_with_variable(line.handles()[-1].pos.x)))
 #        self.assertTrue(list(canvas.solver.constraints_with_variable(line.handles()[-1].pos.y)))
-        
+
 if __name__ == '__main__':
     unittest.main()
 # vim:sw=4:et:ai

--- a/gaphas/tests/test_view.py
+++ b/gaphas/tests/test_view.py
@@ -47,7 +47,7 @@ class ViewTestCase(unittest.TestCase):
         while gtk.events_pending():
             gtk.main_iteration()
 
-        try: 
+        try:
             assert view2.get_item_bounding_box(box)
             assert view1.get_item_bounding_box(box)
             assert view1.get_item_bounding_box(box) == view2.get_item_bounding_box(box), '%s != %s' % (view1.get_item_bounding_box(box), view2.get_item_bounding_box(box))
@@ -153,10 +153,10 @@ class ViewTestCase(unittest.TestCase):
         canvas = Canvas()
 
         # Simple views do not register on the canvas
-        
+
         view = View(canvas)
         assert len(canvas._registered_views) == 0
-        
+
         box = Box()
         canvas.add(box)
 
@@ -168,7 +168,7 @@ class ViewTestCase(unittest.TestCase):
 
         view = GtkView(canvas)
         assert len(canvas._registered_views) == 1
-        
+
         # No entry, since GtkView is not realized and has no window
         assert not box._matrix_i2v.has_key(view)
         assert not box._matrix_v2i.has_key(view)
@@ -222,7 +222,7 @@ class ViewTestCase(unittest.TestCase):
 
         assert not box._matrix_i2v.has_key(view)
         assert not box._matrix_v2i.has_key(view)
-        
+
 
     def test_scroll_adjustments_signal(self):
         def handler(self, hadj, vadj):

--- a/gaphas/tool.py
+++ b/gaphas/tool.py
@@ -54,7 +54,7 @@ Event = Context
 
 class Tool(object):
     """
-    Base class for a tool. This class 
+    Base class for a tool. This class
     A word on click events:
 
     Mouse (pointer) button click. A button press is normally followed by
@@ -197,10 +197,10 @@ class ToolChain(Tool):
         or grabbed.
 
         If a tool is returning True on a button press event, the motion and
-        button release events are also passed to this 
+        button release events are also passed to this
         """
         handler = self.EVENT_HANDLERS.get(event.type)
-        
+
         self.validate_grabbed_tool(event)
 
         if self._grabbed_tool and handler:
@@ -268,7 +268,7 @@ class ItemTool(Tool):
             # Do not move subitems of selected items
             if not set(get_ancestors(item)).intersection(selected_items):
                 yield InMotion(item, view)
-        
+
 
     def on_button_press(self, event):
         ### TODO: make keys configurable
@@ -277,7 +277,7 @@ class ItemTool(Tool):
 
         if event.button not in self._buttons:
             return False
-        
+
         # Deselect all items unless CTRL or SHIFT is pressed
         # or the item is already selected.
         if not (event.state & (gtk.gdk.CONTROL_MASK | gtk.gdk.SHIFT_MASK)
@@ -586,7 +586,7 @@ class ZoomTool(Tool):
             ox = (view._matrix[4] - event.x) / sx
             oy = (view._matrix[5] - event.y) / sy
             factor = 0.9
-            if event.direction == gtk.gdk.SCROLL_UP:    
+            if event.direction == gtk.gdk.SCROLL_UP:
                 factor = 1. / factor
             view._matrix.translate(-ox, -oy)
             view._matrix.scale(factor, factor)

--- a/gaphas/tree.py
+++ b/gaphas/tree.py
@@ -12,7 +12,7 @@ from operator import attrgetter
 class Tree(object):
     """
     A Tree structure. Nodes are stores in a depth-first order.
-    
+
     ``None`` is the root node.
 
     @invariant: len(self._children) == len(self._nodes) + 1
@@ -186,7 +186,7 @@ class Tree(object):
     def sort(self, nodes, index_key, reverse=False):
         """
         Sort a set (or list) of nodes.
-        
+
         >>> class A(object):
         ...     def __init__(self, n):
         ...         self.n = n
@@ -246,7 +246,7 @@ class Tree(object):
         siblings = self._children[parent]
 
         self._add_to_nodes(node, parent, index)
-        
+
         # Fix parent-child and child-parent relationship
         try:
             siblings.insert(index, node)
@@ -302,7 +302,7 @@ class Tree(object):
         self._add_to_nodes(node, parent)
         for c in self._children[node]:
             self._reparent_nodes(c, node)
-        
+
     def reparent(self, node, parent, index=None):
         """
         Set new parent for a ``node``. ``Parent`` can be ``None``, indicating
@@ -323,7 +323,7 @@ class Tree(object):
         ['n1', 'n3', 'n2']
 
         If a node contains children, those are also moved:
-        
+
         >>> tree.add('n4')
         >>> tree.nodes
         ['n1', 'n3', 'n2', 'n4']

--- a/gaphas/view.py
+++ b/gaphas/view.py
@@ -26,7 +26,7 @@ DEFAULT_CURSOR = gtk.gdk.LEFT_PTR
 
 class View(object):
     """
-    View class for gaphas.Canvas objects. 
+    View class for gaphas.Canvas objects.
     """
 
     def __init__(self, canvas=None):
@@ -145,7 +145,7 @@ class View(object):
         Items that loose focus remain selected.
         """
         self._set_focused_item(None)
-        
+
 
     focused_item = property(lambda s: s._focused_item,
                             _set_focused_item, _del_focused_item,
@@ -167,7 +167,7 @@ class View(object):
         Unset the hovered item.
         """
         self._set_hovered_item(None)
-        
+
 
     hovered_item = property(lambda s: s._hovered_item,
                             _set_hovered_item, _del_hovered_item,
@@ -396,7 +396,7 @@ class View(object):
 
     def update_bounding_box(self, cr, items=None):
         """
-        Update the bounding boxes of the canvas items for this view, in 
+        Update the bounding boxes of the canvas items for this view, in
         canvas coordinates.
         """
         painter = self._bounding_box_painter
@@ -483,7 +483,7 @@ class GtkView(gtk.DrawingArea, View):
 
     # Just defined a name to make GTK register this class.
     __gtype_name__ = 'GaphasView'
-    
+
     # Signals: emited after the change takes effect.
     __gsignals__ = {
         'set-scroll-adjustments': (gobject.SIGNAL_RUN_LAST, gobject.TYPE_NONE,
@@ -527,7 +527,7 @@ class GtkView(gtk.DrawingArea, View):
         self.emit('set-scroll-adjustments', hadjustment, vadjustment)
 
         self._set_tool(DefaultTool())
-        
+
         # Set background to white.
         self.modify_bg(gtk.STATE_NORMAL, gtk.gdk.color_parse('#FFF'))
 
@@ -551,7 +551,7 @@ class GtkView(gtk.DrawingArea, View):
             self._canvas.unregister_view(self)
 
         super(GtkView, self)._set_canvas(canvas)
-        
+
         if self._canvas:
             self._canvas.register_view(self)
             self.request_update(self._canvas.get_all_items())
@@ -577,7 +577,7 @@ class GtkView(gtk.DrawingArea, View):
 
     vadjustment = property(lambda s: s._vadjustment)
 
-    
+
     def do_set_scroll_adjustments(self, hadjustment, vadjustment):
         if self._hadjustment_handler_id:
             self._hadjustment.disconnect(self._hadjustment_handler_id)
@@ -787,7 +787,7 @@ class GtkView(gtk.DrawingArea, View):
         gtk.DrawingArea.do_size_allocate(self, allocation)
         self.update_adjustments(allocation)
         self._qtree.resize((0, 0, allocation.width, allocation.height))
-       
+
 
     def do_realize(self):
         gtk.DrawingArea.do_realize(self)

--- a/gaphas/weakset.py
+++ b/gaphas/weakset.py
@@ -31,7 +31,7 @@ class WeakSet:
         return sum(x() is not None for x in self.data)
 
     def __contains__(self, item):
-	"""
+        """
         >>> class C(object): pass
         >>> a = C()
         >>> b = C()
@@ -41,7 +41,7 @@ class WeakSet:
         >>> a = C()
         >>> a in ws
         False
-	"""
+        """
         return ref(item) in self.data
 
     def __reduce__(self):


### PR DESCRIPTION
In this pull request, all trailing whitespace is deleted from `gaphas/*.py` and `gaphas/tests/*.py`. All the unit tests continue to pass correctly.
