### PR TITLE
Fix calculation of port at point in View class

### DIFF
--- a/gaphas/view.py
+++ b/gaphas/view.py
@@ -325,6 +325,7 @@ class View(object):
                 if d >= max_dist:
                     continue
 
+                max_dist = d
                 item = i
                 port = p
 


### PR DESCRIPTION
The method get_port_at_point contained a bug. Instead of calculating the port closest to the given point, it only calculated the last port fulfilling the proximity condition.
