### PR TITLE
Add Support for Python3

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -1,0 +1,11 @@
+[[source]]
+url = "https://pypi.org/simple"
+verify_ssl = true
+name = "pypi"
+
+[packages]
+
+[dev-packages]
+
+[requires]
+python_version = "3.7"

--- a/gaphas/__init__.py
+++ b/gaphas/__init__.py
@@ -19,14 +19,15 @@ used in Gaphas instead of the multiplier (``*``). In both the
 ``Canvas`` and ``View`` class a workaround is provided in case an
 older version of py-cairo is used.
 """
+from __future__ import absolute_import
 
 __version__ = "$Revision$"
 # $HeadURL$
 
 
-from canvas import Canvas
-from connector import Handle
-from item import Item, Line, Element
-from view import View, GtkView
+from .canvas import Canvas
+from .connector import Handle
+from .item import Item, Line, Element
+from .view import View, GtkView
 
 # vi:sw=4:et:ai

--- a/gaphas/aspect.py
+++ b/gaphas/aspect.py
@@ -8,6 +8,7 @@ function. In order to inherit from this class you should inherit from
 Class.default.  The simplegeneric module is dispatching opnly based on
 the first argument.  For Gaphas that's enough.
 """
+from __future__ import absolute_import
 
 import gtk.gdk
 from simplegeneric import generic
@@ -144,7 +145,7 @@ class ElementHandleSelection(ItemHandleSelection):
             self.view.window.set_cursor(self.CURSORS[index])
 
     def unselect(self):
-        from view import DEFAULT_CURSOR
+        from .view import DEFAULT_CURSOR
         cursor = gtk.gdk.Cursor(DEFAULT_CURSOR)
         self.view.window.set_cursor(cursor)
 

--- a/gaphas/aspect.py
+++ b/gaphas/aspect.py
@@ -10,6 +10,7 @@ the first argument.  For Gaphas that's enough.
 """
 from __future__ import absolute_import
 
+from builtins import object
 import gtk.gdk
 from simplegeneric import generic
 from gaphas.item import Item, Element

--- a/gaphas/canvas.py
+++ b/gaphas/canvas.py
@@ -28,6 +28,7 @@ To get connecting items (i.e. all lines connected to a class)::
 """
 from __future__ import absolute_import
 
+from builtins import object
 from builtins import range
 __version__ = "$Revision$"
 # $HeadURL$

--- a/gaphas/canvas.py
+++ b/gaphas/canvas.py
@@ -28,6 +28,7 @@ To get connecting items (i.e. all lines connected to a class)::
 """
 from __future__ import absolute_import
 
+from builtins import range
 __version__ = "$Revision$"
 # $HeadURL$
 
@@ -92,7 +93,7 @@ class Canvas(object):
     def __init__(self):
         self._tree = tree.Tree()
         self._solver = solver.Solver()
-        self._connections = table.Table(Connection, range(4))
+        self._connections = table.Table(Connection, list(range(4)))
         self._dirty_items = set()
         self._dirty_matrix_items = set()
         self._dirty_index = False

--- a/gaphas/canvas.py
+++ b/gaphas/canvas.py
@@ -1009,9 +1009,9 @@ class CanvasProjection(object):
         self._px, self._py = item.canvas.get_matrix_i2c(item).transform_point(x, y)
         return self._px, self._py
 
-    pos = property(lambda self: map(VariableProjection,
+    pos = property(lambda self: list(map(VariableProjection,
                                     self._point, self._get_value(),
-                                    (self._on_change_x, self._on_change_y)))
+                                    (self._on_change_x, self._on_change_y))))
 
     def __getitem__(self, key):
         # Note: we can not use bound methods as callbacks, since that will

--- a/gaphas/canvas.py
+++ b/gaphas/canvas.py
@@ -82,7 +82,7 @@ class Context(object):
         self.__dict__.update(**kwargs)
 
     def __setattr__(self, key, value):
-        raise AttributeError, 'context is not writable'
+        raise AttributeError('context is not writable')
 
 
 class Canvas(object):
@@ -423,7 +423,7 @@ class Canvas(object):
         # checks:
         cinfo = self.get_connection(handle)
         if not cinfo:
-            raise ValueError, 'No data available for item "%s" and handle "%s"' % (item, handle)
+            raise ValueError('No data available for item "%s" and handle "%s"' % (item, handle))
 
         if cinfo.constraint:
             self._solver.remove_constraint(cinfo.constraint)

--- a/gaphas/canvas.py
+++ b/gaphas/canvas.py
@@ -454,7 +454,7 @@ class Canvas(object):
         >>> c.get_connection(ii.handles()[0])    # doctest: +ELLIPSIS
         """
         try:
-            return self._connections.query(handle=handle).next()
+            return next(self._connections.query(handle=handle))
         except StopIteration as ex:
             return None
 

--- a/gaphas/canvas.py
+++ b/gaphas/canvas.py
@@ -26,6 +26,7 @@ To get connecting items (i.e. all lines connected to a class)::
     lines = (c.item for c in canvas.get_connections(connected=item))
 
 """
+from __future__ import absolute_import
 
 __version__ = "$Revision$"
 # $HeadURL$
@@ -38,7 +39,7 @@ from gaphas import tree
 from gaphas import solver
 from gaphas import table
 from gaphas.decorators import nonrecursive, async, PRIORITY_HIGH_IDLE
-from state import observed, reversible_method, reversible_pair
+from .state import observed, reversible_method, reversible_pair
 
 
 #

--- a/gaphas/canvas.py
+++ b/gaphas/canvas.py
@@ -455,7 +455,7 @@ class Canvas(object):
         """
         try:
             return self._connections.query(handle=handle).next()
-        except StopIteration, ex:
+        except StopIteration as ex:
             return None
 
 
@@ -702,7 +702,7 @@ class Canvas(object):
 
             self._post_update_items(dirty_items, cr)
 
-        except Exception, e:
+        except Exception as e:
             logging.error('Error while updating canvas', exc_info=e)
 
         assert len(self._dirty_items) == 0 and len(self._dirty_matrix_items) == 0, \

--- a/gaphas/canvas.py
+++ b/gaphas/canvas.py
@@ -28,6 +28,8 @@ To get connecting items (i.e. all lines connected to a class)::
 """
 from __future__ import absolute_import
 
+from builtins import next
+from builtins import map
 from builtins import object
 from builtins import range
 __version__ = "$Revision$"

--- a/gaphas/connector.py
+++ b/gaphas/connector.py
@@ -2,6 +2,7 @@
 Basic connectors such as Ports and Handles.
 """
 
+from builtins import object
 __version__ = "$Revision: 2341 $"
 # $HeadURL: https://svn.devjavu.com/gaphor/gaphas/trunk/gaphas/item.py $
 

--- a/gaphas/constraint.py
+++ b/gaphas/constraint.py
@@ -31,6 +31,7 @@ a variable with appropriate value.
 from __future__ import division
 from __future__ import absolute_import
 from __future__ import print_function
+from builtins import object
 import operator
 import math
 from .solver import Projection

--- a/gaphas/constraint.py
+++ b/gaphas/constraint.py
@@ -288,7 +288,7 @@ class EquationConstraint(Constraint):
     """
 
     def __init__(self, f, **args):
-        super(EquationConstraint, self).__init__(*args.values())
+        super(EquationConstraint, self).__init__(*list(args.values()))
         self._f = f
         self._args = {}
         # see important note on order of operations in __setattr__ below.
@@ -299,7 +299,7 @@ class EquationConstraint(Constraint):
 
     def __repr__(self):
         argstring = ', '.join(['%s=%s' % (arg, str(value)) for (arg, value) in
-                             self._args.items()])
+                             list(self._args.items())])
         if argstring:
             return 'EquationConstraint(%s, %s)' % (self._f.func_code.co_name, argstring)
         else:
@@ -348,7 +348,7 @@ class EquationConstraint(Constraint):
         constraint.
         """
         args = {}
-        for nm, v in self._args.items():
+        for nm, v in list(self._args.items()):
             args[nm] = v.value
             if v is var: arg = nm
         v = self._solve_for(arg, args)

--- a/gaphas/constraint.py
+++ b/gaphas/constraint.py
@@ -30,6 +30,7 @@ a variable with appropriate value.
 
 from __future__ import division
 from __future__ import absolute_import
+from __future__ import print_function
 import operator
 import math
 from .solver import Projection
@@ -390,14 +391,14 @@ class EquationConstraint(Constraint):
             else:
                 close_flag = False
             if n > ITERLIMIT:
-                print "Failed to converge; exceeded iteration limit"
+                print("Failed to converge; exceeded iteration limit")
                 break
             slope = (fx1 - fx0) / (x1 - x0)
             if slope == 0:
                 if close_flag:  # we're close but have zero slope, finish
                     break
                 else:
-                    print 'Zero slope and not close enough to solution'
+                    print('Zero slope and not close enough to solution')
                     break
             x2 = x0 - fx0 / slope           # New 'x1'
             fx0 = fx1

--- a/gaphas/constraint.py
+++ b/gaphas/constraint.py
@@ -31,6 +31,7 @@ a variable with appropriate value.
 from __future__ import division
 from __future__ import absolute_import
 from __future__ import print_function
+from builtins import str
 from builtins import object
 import operator
 import math

--- a/gaphas/constraint.py
+++ b/gaphas/constraint.py
@@ -29,9 +29,10 @@ a variable with appropriate value.
 """
 
 from __future__ import division
+from __future__ import absolute_import
 import operator
 import math
-from solver import Projection
+from .solver import Projection
 
 
 __version__ = "$Revision$"

--- a/gaphas/constraint.py
+++ b/gaphas/constraint.py
@@ -292,7 +292,7 @@ class EquationConstraint(Constraint):
         self._f = f
         self._args = {}
         # see important note on order of operations in __setattr__ below.
-        for arg in f.func_code.co_varnames[0:f.func_code.co_argcount]:
+        for arg in f.__code__.co_varnames[0:f.__code__.co_argcount]:
             self._args[arg] = None
         self._set(**args)
 
@@ -301,9 +301,9 @@ class EquationConstraint(Constraint):
         argstring = ', '.join(['%s=%s' % (arg, str(value)) for (arg, value) in
                              list(self._args.items())])
         if argstring:
-            return 'EquationConstraint(%s, %s)' % (self._f.func_code.co_name, argstring)
+            return 'EquationConstraint(%s, %s)' % (self._f.__code__.co_name, argstring)
         else:
-            return 'EquationConstraint(%s)' % self._f.func_code.co_name
+            return 'EquationConstraint(%s)' % self._f.__code__.co_name
 
 
     def __getattr__(self, name):

--- a/gaphas/constraint.py
+++ b/gaphas/constraint.py
@@ -376,7 +376,7 @@ class EquationConstraint(Constraint):
             return self._f(**args)
         fx0 = f(x0)
         n = 0
-        while 1:                    # Newton's method loop here
+        while True:                    # Newton's method loop here
             fx1 = f(x1)
             if fx1 == 0 or x1 == x0:  # managed to nail it exactly
                 break

--- a/gaphas/constraint.py
+++ b/gaphas/constraint.py
@@ -329,7 +329,7 @@ class EquationConstraint(Constraint):
             elif name in self.__dict__:
                 self.__dict__[name] = value
             else:
-                raise KeyError, name
+                raise KeyError(name)
         else:
             object.__setattr__(self, name, value)
 

--- a/gaphas/constraint.py
+++ b/gaphas/constraint.py
@@ -322,7 +322,7 @@ class EquationConstraint(Constraint):
         # be added to self.__dict__.  This is a good thing as it throws
         # an exception if you try to assign to an arg which is inappropriate
         # for the function in the solver.
-        if self.__dict__.has_key('_args'):
+        if '_args' in self.__dict__:
             if name in self._args:
                 self._args[name] = value
             elif name in self.__dict__:

--- a/gaphas/decorators.py
+++ b/gaphas/decorators.py
@@ -3,6 +3,7 @@ Custom decorators.
 """
 from __future__ import print_function
 
+from builtins import object
 __version__ = "$Revision$"
 # $HeadURL$
 

--- a/gaphas/decorators.py
+++ b/gaphas/decorators.py
@@ -132,7 +132,7 @@ class async(object):
                 try:
                     if getattr(holder, async_id):
                         return
-                except AttributeError, e:
+                except AttributeError as e:
                     def async_wrapper():
                         if DEBUG_ASYNC: print 'async:', func, args, kwargs
                         try:

--- a/gaphas/decorators.py
+++ b/gaphas/decorators.py
@@ -1,6 +1,7 @@
 """
 Custom decorators.
 """
+from __future__ import print_function
 
 __version__ = "$Revision$"
 # $HeadURL$
@@ -123,7 +124,7 @@ class async(object):
                 return func(*args, **kwargs)
             elif not self.single:
                 def async_wrapper():
-                    if DEBUG_ASYNC: print 'async:', func, args, kwargs
+                    if DEBUG_ASYNC: print('async:', func, args, kwargs)
                     func(*args, **kwargs)
                 source(async_wrapper).attach()
             else:
@@ -134,7 +135,7 @@ class async(object):
                         return
                 except AttributeError as e:
                     def async_wrapper():
-                        if DEBUG_ASYNC: print 'async:', func, args, kwargs
+                        if DEBUG_ASYNC: print('async:', func, args, kwargs)
                         try:
                             func(*args, **kwargs)
                         finally:

--- a/gaphas/examples.py
+++ b/gaphas/examples.py
@@ -3,7 +3,9 @@ Simple example items.
 These items are used in various tests.
 """
 from __future__ import absolute_import
+from __future__ import division
 
+from past.utils import old_div
 __version__ = "$Revision$"
 # $HeadURL$
 
@@ -68,7 +70,7 @@ class PortoBox(Box):
 
         # handle for movable port
         self._hm = Handle(strength=WEAK)
-        self._hm.pos = width, height / 2.0
+        self._hm.pos = width, old_div(height, 2.0)
         self._handles.append(self._hm)
 
         # movable port
@@ -80,7 +82,7 @@ class PortoBox(Box):
         self.constraint(above=(self._hm.pos, se.pos))
 
         # static point port
-        self._sport = PointPort(Position((width / 2.0, height)))
+        self._sport = PointPort(Position((old_div(width, 2.0), height)))
         l = sw.pos, se.pos
         self.constraint(line=(self._sport.point, l))
         self._ports.append(self._sport)

--- a/gaphas/examples.py
+++ b/gaphas/examples.py
@@ -2,6 +2,7 @@
 Simple example items.
 These items are used in various tests.
 """
+from __future__ import absolute_import
 
 __version__ = "$Revision$"
 # $HeadURL$
@@ -9,8 +10,8 @@ __version__ = "$Revision$"
 from gaphas.item import Element, Item, NW, NE,SW, SE
 from gaphas.connector import Handle, PointPort, LinePort, Position
 from gaphas.solver import solvable, WEAK
-import tool
-from util import text_align, text_multiline, path_ellipse
+from . import tool
+from .util import text_align, text_multiline, path_ellipse
 
 class Box(Element):
     """ A Box has 4 handles (for a start):

--- a/gaphas/freehand.py
+++ b/gaphas/freehand.py
@@ -12,6 +12,7 @@ See: http://stevehanov.ca/blog/index.php?id=33 and
 """
 from __future__ import absolute_import
 
+from builtins import object
 from math import sqrt
 from random import Random
 from .painter import Context

--- a/gaphas/freehand.py
+++ b/gaphas/freehand.py
@@ -10,10 +10,11 @@ Cairo context using Steve Hanov's freehand drawing code.
 See: http://stevehanov.ca/blog/index.php?id=33 and
      http://stevehanov.ca/blog/index.php?id=93
 """
+from __future__ import absolute_import
 
 from math import sqrt
 from random import Random
-from painter import Context
+from .painter import Context
 
 
 class FreeHandCairoContext(object):

--- a/gaphas/geometry.py
+++ b/gaphas/geometry.py
@@ -159,7 +159,7 @@ class Rectangle(object):
         try:
             x, y, width, height = obj
         except ValueError:
-            raise TypeError, "Can only add Rectangle or tuple (x, y, width, height), not %s." % repr(obj)
+            raise TypeError("Can only add Rectangle or tuple (x, y, width, height), not %s." % repr(obj))
         x1, y1 = x + width, y + height
         if self:
             ox1, oy1 = self.x + self.width, self.y + self.height
@@ -199,7 +199,7 @@ class Rectangle(object):
         try:
             x, y, width, height = obj
         except ValueError:
-            raise TypeError, "Can only substract Rectangle or tuple (x, y, width, height), not %s." % repr(obj)
+            raise TypeError("Can only substract Rectangle or tuple (x, y, width, height), not %s." % repr(obj))
         x1, y1 = x + width, y + height
 
         if self:
@@ -249,7 +249,7 @@ class Rectangle(object):
                 x, y = obj
                 x1, y1 = obj
             except ValueError:
-                raise TypeError, "Should compare to Rectangle, tuple (x, y, width, height) or point (x, y), not %s." % repr(obj)
+                raise TypeError("Should compare to Rectangle, tuple (x, y, width, height) or point (x, y), not %s." % repr(obj))
         return x >= self.x and x1 <= self.x1 and \
                y >= self.y and y1 <= self.y1
 

--- a/gaphas/geometry.py
+++ b/gaphas/geometry.py
@@ -110,7 +110,7 @@ class Rectangle(object):
         """
         return (self.x, self.y, self.width, self.height)[index]
 
-    def __nonzero__(self):
+    def __bool__(self):
         """
         >>> r=Rectangle(1,2,3,4)
         >>> if r: 'yes'

--- a/gaphas/geometry.py
+++ b/gaphas/geometry.py
@@ -9,6 +9,7 @@ A point is represented as a tuple `(x, y)`.
 """
 from __future__ import division
 
+from builtins import object
 from past.utils import old_div
 __version__ = "$Revision$"
 # $HeadURL$

--- a/gaphas/geometry.py
+++ b/gaphas/geometry.py
@@ -7,7 +7,9 @@ intersections).
 A point is represented as a tuple `(x, y)`.
 
 """
+from __future__ import division
 
+from past.utils import old_div
 __version__ = "$Revision$"
 # $HeadURL$
 
@@ -361,12 +363,12 @@ def point_on_rectangle(rect, point, border=False):
         # Find point on side closest to the point
         if min(abs(rx - px), abs(rx + rw - px)) > \
            min(abs(ry - py), abs(ry + rh - py)):
-            if py < ry + rh / 2.:
+            if py < ry + old_div(rh, 2.):
                 py = ry
             else:
                 py = ry + rh
         else:
-            if px < rx + rw / 2.:
+            if px < rx + old_div(rw, 2.):
                 px = rx
             else:
                 px = rx + rw
@@ -406,7 +408,7 @@ def distance_line_point(line_start, line_end, point):
     if line_len_sqr < 0.0001:
         return distance_point_point(point), line_start
 
-    projlen = (line_end[0] * point[0] + line_end[1] * point[1]) / line_len_sqr
+    projlen = old_div((line_end[0] * point[0] + line_end[1] * point[1]), line_len_sqr)
 
     if projlen < 0.0:
         # Closest point is the start of the line.
@@ -534,17 +536,17 @@ def intersect_line_line(line1_start, line1_end, line2_start, line2_end):
     denom = a1 * b2 - a2 * b1
     if not denom:
         return None # ( COLLINEAR )
-    offset = abs(denom) / 2
+    offset = old_div(abs(denom), 2)
 
     # The denom/2 is to get rounding instead of truncating.  It
     # is added or subtracted to the numerator, depending upon the
     # sign of the numerator.
 
     num = b1 * c2 - b2 * c1
-    x = ( (num < 0) and (num - offset) or (num + offset) ) / denom
+    x = old_div(( (num < 0) and (num - offset) or (num + offset) ), denom)
 
     num = a2 * c1 - a1 * c2
-    y = ( (num < 0) and (num - offset) or (num + offset) ) / denom
+    y = old_div(( (num < 0) and (num - offset) or (num + offset) ), denom)
 
     return x, y
 

--- a/gaphas/geometry.py
+++ b/gaphas/geometry.py
@@ -121,7 +121,7 @@ class Rectangle(object):
         return self.width > 0 and self.height > 0
 
     def __eq__(self, other):
-        return (type(self) is type(other)) \
+        return (isinstance(self, type(other))) \
                 and self.x == other.x \
                 and self.y == other.y \
                 and self.width == other.width \

--- a/gaphas/guide.py
+++ b/gaphas/guide.py
@@ -3,6 +3,7 @@ Module implements guides when moving items and handles around.
 """
 from __future__ import division
 
+from builtins import map
 from builtins import object
 from past.utils import old_div
 from simplegeneric import generic

--- a/gaphas/guide.py
+++ b/gaphas/guide.py
@@ -156,7 +156,7 @@ class GuideMixin(object):
     def get_view_dimensions(self):
         try:
             allocation = self.view.allocation
-        except AttributeError, e:
+        except AttributeError as e:
             return 0, 0
         return allocation.width, allocation.height
 

--- a/gaphas/guide.py
+++ b/gaphas/guide.py
@@ -7,6 +7,7 @@ from gaphas.aspect import InMotion, HandleInMotion, PaintFocused
 from gaphas.aspect import ItemInMotion, ItemHandleInMotion, ItemPaintFocused
 from gaphas.connector import Handle
 from gaphas.item import Item, Element, Line, SE
+from functools import reduce
 
 
 class ItemGuide(object):

--- a/gaphas/guide.py
+++ b/gaphas/guide.py
@@ -1,7 +1,9 @@
 """
 Module implements guides when moving items and handles around.
 """
+from __future__ import division
 
+from past.utils import old_div
 from simplegeneric import generic
 from gaphas.aspect import InMotion, HandleInMotion, PaintFocused
 from gaphas.aspect import ItemInMotion, ItemHandleInMotion, ItemPaintFocused
@@ -39,11 +41,11 @@ class ElementGuide(ItemGuide):
 
     def horizontal(self):
         y = self.item.height
-        return (0, y/2, y)
+        return (0, old_div(y,2), y)
 
     def vertical(self):
         x = self.item.width
-        return (0, x/2, x)
+        return (0, old_div(x,2), x)
 
 
 @Guide.when_type(Line)

--- a/gaphas/guide.py
+++ b/gaphas/guide.py
@@ -3,6 +3,7 @@ Module implements guides when moving items and handles around.
 """
 from __future__ import division
 
+from builtins import object
 from past.utils import old_div
 from simplegeneric import generic
 from gaphas.aspect import InMotion, HandleInMotion, PaintFocused

--- a/gaphas/guide.py
+++ b/gaphas/guide.py
@@ -105,7 +105,7 @@ class GuideMixin(object):
         for x in item_vedges:
             items.append(view.get_items_in_rectangle((x - margin, 0, margin*2, height)))
         try:
-            guides = map(Guide, reduce(set.union, map(set, items)) - excluded_items)
+            guides = list(map(Guide, reduce(set.union, list(map(set, items))) - excluded_items))
         except TypeError:
             guides = []
 
@@ -126,7 +126,7 @@ class GuideMixin(object):
         for y in item_hedges:
             items.append(view.get_items_in_rectangle((0, y - margin, width, margin*2)))
         try:
-            guides = map(Guide, reduce(set.union, map(set, items)) - excluded_items)
+            guides = list(map(Guide, reduce(set.union, list(map(set, items))) - excluded_items))
         except TypeError:
             guides = []
 

--- a/gaphas/item.py
+++ b/gaphas/item.py
@@ -674,8 +674,8 @@ class Line(Item):
 
         # create a list of (distance, point_on_line) tuples:
         distances = list(map(distance_line_point, hpos[:-1], hpos[1:], [pos] * (len(hpos) - 1)))
-        distances, pols = zip(*distances)
-        return reduce(min, zip(distances, pols, range(len(distances))))
+        distances, pols = list(zip(*distances))
+        return reduce(min, list(zip(distances, pols, range(len(distances)))))
 
     def point(self, pos):
         """

--- a/gaphas/item.py
+++ b/gaphas/item.py
@@ -3,6 +3,8 @@ Basic items.
 """
 from __future__ import absolute_import
 
+from builtins import zip
+from builtins import map
 from builtins import object
 from builtins import range
 __version__ = "$Revision$"
@@ -311,7 +313,7 @@ class Item(object):
 [ NW,
   NE,
   SE,
-  SW ] = range(4)
+  SW ] = list(range(4))
 
 class Element(Item):
     """

--- a/gaphas/item.py
+++ b/gaphas/item.py
@@ -7,6 +7,7 @@ __version__ = "$Revision$"
 
 from math import atan2
 from weakref import WeakKeyDictionary
+from functools import reduce
 try:
     # python 3.0 (better be prepared)
     from weakref import WeakSet

--- a/gaphas/item.py
+++ b/gaphas/item.py
@@ -553,7 +553,7 @@ class Line(Item):
         False
         """
         if orthogonal and len(self.handles()) < 3:
-            raise ValueError, "Can't set orthogonal line with less than 3 handles"
+            raise ValueError("Can't set orthogonal line with less than 3 handles")
         self._update_orthogonal_constraints(orthogonal)
 
     orthogonal = reversible_property(lambda s: bool(s._orthogonal_constraints), _set_orthogonal)

--- a/gaphas/item.py
+++ b/gaphas/item.py
@@ -168,7 +168,7 @@ class Item(object):
         updated = False
         handles = self._handles
         if handles:
-            x, y = map(float, handles[0].pos)
+            x, y = list(map(float, handles[0].pos))
             if x:
                 self.matrix.translate(x, 0)
                 updated = True
@@ -425,7 +425,7 @@ class Element(Item):
         updated = False
         handles = self._handles
         handles = (handles[NW], handles[SE])
-        x, y = map(float, handles[0].pos)
+        x, y = list(map(float, handles[0].pos))
         if x:
             self.matrix.translate(x, 0)
             updated = True
@@ -448,7 +448,7 @@ class Element(Item):
         """
         h = self._handles
         pnw, pse = h[NW].pos, h[SE].pos
-        return distance_rectangle_point(map(float, (pnw.x, pnw.y, pse.x, pse.y)), pos)
+        return distance_rectangle_point(list(map(float, (pnw.x, pnw.y, pse.x, pse.y))), pos)
 
 
 class Line(Item):
@@ -669,10 +669,10 @@ class Line(Item):
         (0.7071067811865476, (4.5, 4.5), 0)
         """
         h = self._handles
-        hpos = map(getattr, h, ['pos'] * len(h))
+        hpos = list(map(getattr, h, ['pos'] * len(h)))
 
         # create a list of (distance, point_on_line) tuples:
-        distances = map(distance_line_point, hpos[:-1], hpos[1:], [pos] * (len(hpos) - 1))
+        distances = list(map(distance_line_point, hpos[:-1], hpos[1:], [pos] * (len(hpos) - 1)))
         distances, pols = zip(*distances)
         return reduce(min, zip(distances, pols, range(len(distances))))
 

--- a/gaphas/item.py
+++ b/gaphas/item.py
@@ -1,6 +1,7 @@
 """
 Basic items.
 """
+from __future__ import absolute_import
 
 __version__ = "$Revision$"
 # $HeadURL$
@@ -12,14 +13,14 @@ try:
     # python 3.0 (better be prepared)
     from weakref import WeakSet
 except ImportError:
-    from weakset import WeakSet
+    from .weakset import WeakSet
 
-from matrix import Matrix
-from geometry import distance_line_point, distance_rectangle_point
-from connector import Handle, LinePort
-from solver import solvable, WEAK, NORMAL, STRONG, VERY_STRONG, REQUIRED
-from constraint import EqualsConstraint, LessThanConstraint, LineConstraint, LineAlignConstraint
-from state import observed, reversible_method, reversible_pair, reversible_property
+from .matrix import Matrix
+from .geometry import distance_line_point, distance_rectangle_point
+from .connector import Handle, LinePort
+from .solver import solvable, WEAK, NORMAL, STRONG, VERY_STRONG, REQUIRED
+from .constraint import EqualsConstraint, LessThanConstraint, LineConstraint, LineAlignConstraint
+from .state import observed, reversible_method, reversible_pair, reversible_property
 
 class Item(object):
     """

--- a/gaphas/item.py
+++ b/gaphas/item.py
@@ -3,6 +3,7 @@ Basic items.
 """
 from __future__ import absolute_import
 
+from builtins import object
 from builtins import range
 __version__ = "$Revision$"
 # $HeadURL$

--- a/gaphas/item.py
+++ b/gaphas/item.py
@@ -3,6 +3,7 @@ Basic items.
 """
 from __future__ import absolute_import
 
+from builtins import range
 __version__ = "$Revision$"
 # $HeadURL$
 
@@ -309,7 +310,7 @@ class Item(object):
 [ NW,
   NE,
   SE,
-  SW ] = xrange(4)
+  SW ] = range(4)
 
 class Element(Item):
     """
@@ -676,7 +677,7 @@ class Line(Item):
         # create a list of (distance, point_on_line) tuples:
         distances = list(map(distance_line_point, hpos[:-1], hpos[1:], [pos] * (len(hpos) - 1)))
         distances, pols = list(zip(*distances))
-        return reduce(min, list(zip(distances, pols, range(len(distances)))))
+        return reduce(min, list(zip(distances, pols, list(range(len(distances))))))
 
     def point(self, pos):
         """

--- a/gaphas/matrix.py
+++ b/gaphas/matrix.py
@@ -10,6 +10,7 @@ state preservation capabilities.
 from __future__ import absolute_import
 from __future__ import division
 
+from builtins import object
 from past.utils import old_div
 __version__ = "$Revision$"
 # $HeadURL$

--- a/gaphas/matrix.py
+++ b/gaphas/matrix.py
@@ -8,7 +8,9 @@ Small utility class wrapping cairo.Matrix. The `Matrix` class adds
 state preservation capabilities.
 """
 from __future__ import absolute_import
+from __future__ import division
 
+from past.utils import old_div
 __version__ = "$Revision$"
 # $HeadURL$
 
@@ -57,7 +59,7 @@ class Matrix(object):
     reversible_method(rotate, rotate,
                       { 'radians': lambda radians: -radians })
     reversible_method(scale, scale,
-                      { 'sx': lambda sx: 1/sx, 'sy': lambda sy: 1/sy })
+                      { 'sx': lambda sx: old_div(1,sx), 'sy': lambda sy: old_div(1,sy) })
     reversible_method(translate, translate,
                       { 'tx': lambda tx: -tx, 'ty': lambda ty: -ty })
 

--- a/gaphas/matrix.py
+++ b/gaphas/matrix.py
@@ -7,12 +7,13 @@ Matrix
 Small utility class wrapping cairo.Matrix. The `Matrix` class adds
 state preservation capabilities.
 """
+from __future__ import absolute_import
 
 __version__ = "$Revision$"
 # $HeadURL$
 
 import cairo
-from state import observed, reversible_method
+from .state import observed, reversible_method
 
 
 class Matrix(object):

--- a/gaphas/painter.py
+++ b/gaphas/painter.py
@@ -6,7 +6,9 @@ Painters can be swapped in and out.
 Each painter takes care of a layer in the canvas (such as grid, items
 and handles).
 """
+from __future__ import division
 
+from past.utils import old_div
 __version__ = "$Revision$"
 # $HeadURL$
 
@@ -188,7 +190,7 @@ class CairoBoundingBoxContext(object):
         cr.restore()
         if b and line_width:
             # Do this after the restore(), so we can get the proper width.
-            lw = cr.get_line_width()/2
+            lw = old_div(cr.get_line_width(),2)
             d = cr.user_to_device_distance(lw, lw)
             b.expand(d[0]+d[1])
         self._update_bounds(b)
@@ -324,7 +326,7 @@ class HandlePainter(Painter):
                 cairo.line_to(2, 3)
                 cairo.move_to(2, -2)
                 cairo.line_to(-2, 3)
-            cairo.set_source_rgba(r/4., g/4., b/4., opacity*1.3)
+            cairo.set_source_rgba(old_div(r,4.), old_div(g,4.), old_div(b,4.), opacity*1.3)
             cairo.stroke()
         cairo.restore()
 

--- a/gaphas/painter.py
+++ b/gaphas/painter.py
@@ -8,6 +8,7 @@ and handles).
 """
 from __future__ import division
 
+from builtins import object
 from past.utils import old_div
 __version__ = "$Revision$"
 # $HeadURL$

--- a/gaphas/picklers.py
+++ b/gaphas/picklers.py
@@ -14,7 +14,7 @@ def construct_instancemethod(funcname, self, clazz):
     return new.instancemethod(func, self, clazz)
 
 def reduce_instancemethod(im):
-    return construct_instancemethod, (im.im_func.__name__, im.im_self, im.im_class)
+    return construct_instancemethod, (im.__func__.__name__, im.__self__, im.__self__.__class__)
 
 copy_reg.pickle(new.instancemethod, reduce_instancemethod, construct_instancemethod)
 

--- a/gaphas/picklers.py
+++ b/gaphas/picklers.py
@@ -2,7 +2,9 @@
 Some extra picklers needed to gracefully dump and load a canvas.
 """
 
-import copy_reg
+from future import standard_library
+standard_library.install_aliases()
+import copyreg
 
 
 # Allow instancemethod to be pickled:
@@ -16,7 +18,7 @@ def construct_instancemethod(funcname, self, clazz):
 def reduce_instancemethod(im):
     return construct_instancemethod, (im.__func__.__name__, im.__self__, im.__self__.__class__)
 
-copy_reg.pickle(new.instancemethod, reduce_instancemethod, construct_instancemethod)
+copyreg.pickle(new.instancemethod, reduce_instancemethod, construct_instancemethod)
 
 
 # Allow cairo.Matrix to be pickled:
@@ -29,7 +31,7 @@ def construct_cairo_matrix(*args):
 def reduce_cairo_matrix(m):
     return construct_cairo_matrix, tuple(m)
 
-copy_reg.pickle(cairo.Matrix, reduce_cairo_matrix, construct_cairo_matrix)
+copyreg.pickle(cairo.Matrix, reduce_cairo_matrix, construct_cairo_matrix)
 
 
 # vim:sw=4:et:ai

--- a/gaphas/quadtree.py
+++ b/gaphas/quadtree.py
@@ -21,6 +21,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+from builtins import object
 from past.utils import old_div
 __version__ = "$Revision$"
 # $HeadURL$

--- a/gaphas/quadtree.py
+++ b/gaphas/quadtree.py
@@ -19,6 +19,7 @@ as a Q-tree. All forms of Quadtrees share some common features:
 """
 from __future__ import absolute_import
 from __future__ import division
+from __future__ import print_function
 
 from past.utils import old_div
 __version__ = "$Revision$"
@@ -381,10 +382,10 @@ class QuadtreeBucket(object):
 
 
     def dump(self, indent=''):
-       print indent, self, self.bounds
+       print(indent, self, self.bounds)
        indent += '   '
        for item, bounds in sorted(self.items.items()):
-           print indent, item, bounds
+           print(indent, item, bounds)
        for bucket in self._buckets:
            bucket.dump(indent)
 

--- a/gaphas/quadtree.py
+++ b/gaphas/quadtree.py
@@ -130,7 +130,7 @@ class Quadtree(object):
         >>> qtree.bounds
         (0, 0, 0, 0)
         """
-        x_y_w_h = zip(*list(map(operator.getitem, iter(self._ids.values()), [0] * len(self._ids))))
+        x_y_w_h = list(zip(*list(map(operator.getitem, iter(self._ids.values()), [0] * len(self._ids)))))
         if not x_y_w_h:
             return 0, 0, 0, 0
         x0 = min(x_y_w_h[0])

--- a/gaphas/quadtree.py
+++ b/gaphas/quadtree.py
@@ -18,7 +18,9 @@ as a Q-tree. All forms of Quadtrees share some common features:
 (From Wikipedia, the free encyclopedia)
 """
 from __future__ import absolute_import
+from __future__ import division
 
+from past.utils import old_div
 __version__ = "$Revision$"
 # $HeadURL$
 
@@ -294,7 +296,7 @@ class QuadtreeBucket(object):
         # create new subnodes if threshold is reached
         if not self._buckets and len(self.items) >= self.capacity:
             x, y, w, h = self.bounds
-            rw, rh = w / 2., h / 2.
+            rw, rh = old_div(w, 2.), old_div(h, 2.)
             cx, cy = x + rw, y + rh
             self._buckets = [QuadtreeBucket((x, y, rw, rh), self.capacity),
                              QuadtreeBucket((cx, y, rw, rh), self.capacity),
@@ -338,7 +340,7 @@ class QuadtreeBucket(object):
         """
         if self._buckets:
             sx, sy, sw, sh = self.bounds
-            cx, cy = sx + sw / 2., sy + sh / 2.
+            cx, cy = sx + old_div(sw, 2.), sy + old_div(sh, 2.)
             x, y, w, h = bounds
             index = 0
             if x >= cx:

--- a/gaphas/quadtree.py
+++ b/gaphas/quadtree.py
@@ -130,7 +130,7 @@ class Quadtree(object):
         >>> qtree.bounds
         (0, 0, 0, 0)
         """
-        x_y_w_h = zip(*map(operator.getitem, self._ids.itervalues(), [0] * len(self._ids)))
+        x_y_w_h = zip(*map(operator.getitem, iter(self._ids.values()), [0] * len(self._ids)))
         if not x_y_w_h:
             return 0, 0, 0, 0
         x0 = min(x_y_w_h[0])
@@ -199,7 +199,7 @@ class Quadtree(object):
         # Clean bucket and items:
         self._bucket.clear()
 
-        for item, (bounds, data, _) in dict(self._ids).iteritems():
+        for item, (bounds, data, _) in dict(self._ids).items():
             clipped_bounds = rectangle_clip(bounds, self._bucket.bounds)
             if clipped_bounds:
                 self._bucket.find_bucket(clipped_bounds).add(item, clipped_bounds)
@@ -300,7 +300,7 @@ class QuadtreeBucket(object):
                              QuadtreeBucket((x, cy, rw, rh), self.capacity),
                              QuadtreeBucket((cx, cy, rw, rh), self.capacity)]
             # Add items to subnodes
-            items = self.items.items()
+            items = list(self.items.items())
             self.items.clear()
             for i, b in items:
                 self.find_bucket(b).add(i, b)
@@ -361,7 +361,7 @@ class QuadtreeBucket(object):
         Returns an iterator.
         """
         if rectangle_intersects(rect, self.bounds):
-            for item, bounds in self.items.iteritems():
+            for item, bounds in self.items.items():
                 if method(bounds, rect):
                     yield item
             for bucket in self._buckets:
@@ -380,7 +380,7 @@ class QuadtreeBucket(object):
     def dump(self, indent=''):
        print indent, self, self.bounds
        indent += '   '
-       for item, bounds in sorted(self.items.iteritems()):
+       for item, bounds in sorted(self.items.items()):
            print indent, item, bounds
        for bucket in self._buckets:
            bucket.dump(indent)

--- a/gaphas/quadtree.py
+++ b/gaphas/quadtree.py
@@ -21,6 +21,8 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+from builtins import zip
+from builtins import map
 from builtins import object
 from past.utils import old_div
 __version__ = "$Revision$"
@@ -135,7 +137,7 @@ class Quadtree(object):
         >>> qtree.bounds
         (0, 0, 0, 0)
         """
-        x_y_w_h = list(zip(*list(map(operator.getitem, iter(self._ids.values()), [0] * len(self._ids)))))
+        x_y_w_h = list(zip(*list(map(operator.getitem, iter(list(self._ids.values())), [0] * len(self._ids)))))
         if not x_y_w_h:
             return 0, 0, 0, 0
         x0 = min(x_y_w_h[0])
@@ -204,7 +206,7 @@ class Quadtree(object):
         # Clean bucket and items:
         self._bucket.clear()
 
-        for item, (bounds, data, _) in dict(self._ids).items():
+        for item, (bounds, data, _) in list(dict(self._ids).items()):
             clipped_bounds = rectangle_clip(bounds, self._bucket.bounds)
             if clipped_bounds:
                 self._bucket.find_bucket(clipped_bounds).add(item, clipped_bounds)
@@ -366,7 +368,7 @@ class QuadtreeBucket(object):
         Returns an iterator.
         """
         if rectangle_intersects(rect, self.bounds):
-            for item, bounds in self.items.items():
+            for item, bounds in list(self.items.items()):
                 if method(bounds, rect):
                     yield item
             for bucket in self._buckets:

--- a/gaphas/quadtree.py
+++ b/gaphas/quadtree.py
@@ -17,12 +17,13 @@ as a Q-tree. All forms of Quadtrees share some common features:
 
 (From Wikipedia, the free encyclopedia)
 """
+from __future__ import absolute_import
 
 __version__ = "$Revision$"
 # $HeadURL$
 
 import operator
-from geometry import rectangle_contains, rectangle_intersects, rectangle_clip
+from .geometry import rectangle_contains, rectangle_intersects, rectangle_clip
 
 
 class Quadtree(object):

--- a/gaphas/quadtree.py
+++ b/gaphas/quadtree.py
@@ -130,14 +130,14 @@ class Quadtree(object):
         >>> qtree.bounds
         (0, 0, 0, 0)
         """
-        x_y_w_h = zip(*map(operator.getitem, iter(self._ids.values()), [0] * len(self._ids)))
+        x_y_w_h = zip(*list(map(operator.getitem, iter(self._ids.values()), [0] * len(self._ids))))
         if not x_y_w_h:
             return 0, 0, 0, 0
         x0 = min(x_y_w_h[0])
         y0 = min(x_y_w_h[1])
         add = operator.add
-        x1 = max(map(add, x_y_w_h[0], x_y_w_h[2]))
-        y1 = max(map(add, x_y_w_h[1], x_y_w_h[3]))
+        x1 = max(list(map(add, x_y_w_h[0], x_y_w_h[2])))
+        y1 = max(list(map(add, x_y_w_h[1], x_y_w_h[3])))
         return (x0, y0, x1 - x0, y1 - y0)
 
     soft_bounds = property(get_soft_bounds)

--- a/gaphas/segment.py
+++ b/gaphas/segment.py
@@ -3,6 +3,7 @@ Allow for easily adding segments to lines.
 """
 from __future__ import division
 
+from builtins import object
 from past.utils import old_div
 from cairo import Matrix, ANTIALIAS_NONE
 from simplegeneric import generic

--- a/gaphas/segment.py
+++ b/gaphas/segment.py
@@ -1,7 +1,9 @@
 """
 Allow for easily adding segments to lines.
 """
+from __future__ import division
 
+from past.utils import old_div
 from cairo import Matrix, ANTIALIAS_NONE
 from simplegeneric import generic
 from gaphas.geometry import distance_point_point_fast, distance_line_point
@@ -30,8 +32,8 @@ class LineSegment(object):
         handles = item.handles()
         x, y = self.view.get_matrix_v2i(item).transform_point(*pos)
         for h1, h2 in zip(handles, handles[1:]):
-            xp = (h1.pos.x + h2.pos.x) / 2
-            yp = (h1.pos.y + h2.pos.y) / 2
+            xp = old_div((h1.pos.x + h2.pos.x), 2)
+            yp = old_div((h1.pos.y + h2.pos.y), 2)
             if distance_point_point_fast((x,y), (xp, yp)) <= 4:
                 segment = handles.index(h1)
                 handles, ports = self.split_segment(segment)
@@ -63,7 +65,7 @@ class LineSegment(object):
             p0 = handles[segment].pos
             p1 = handles[segment + 1].pos
             dx, dy = p1.x - p0.x, p1.y - p0.y
-            new_h = item._create_handle((p0.x + dx / count, p0.y + dy / count))
+            new_h = item._create_handle((p0.x + old_div(dx, count), p0.y + old_div(dy, count)))
             item._reversible_insert_handle(segment + 1, new_h)
 
             p0 = item._create_port(p0, new_h.pos)
@@ -247,8 +249,8 @@ class LineSegmentPainter(ItemPaintFocused):
             h = item.handles()
             for h1, h2 in zip(h[:-1], h[1:]):
                 p1, p2 = h1.pos, h2.pos
-                cx = (p1.x + p2.x) / 2
-                cy = (p1.y + p2.y) / 2
+                cx = old_div((p1.x + p2.x), 2)
+                cy = old_div((p1.y + p2.y), 2)
                 cr.save()
                 cr.identity_matrix()
                 m = Matrix(*view.get_matrix_i2v(item))

--- a/gaphas/segment.py
+++ b/gaphas/segment.py
@@ -3,6 +3,7 @@ Allow for easily adding segments to lines.
 """
 from __future__ import division
 
+from builtins import zip
 from builtins import object
 from past.utils import old_div
 from cairo import Matrix, ANTIALIAS_NONE

--- a/gaphas/solver.py
+++ b/gaphas/solver.py
@@ -37,6 +37,7 @@ variables to make the constraint valid again.
 from __future__ import division
 from __future__ import absolute_import
 
+from builtins import object
 __version__ = "$Revision$"
 # $HeadURL$
 

--- a/gaphas/solver.py
+++ b/gaphas/solver.py
@@ -35,12 +35,13 @@ variables to make the constraint valid again.
 """
 
 from __future__ import division
+from __future__ import absolute_import
 
 __version__ = "$Revision$"
 # $HeadURL$
 
 from operator import isCallable
-from state import observed, reversible_pair, reversible_property
+from .state import observed, reversible_pair, reversible_property
 
 # epsilon for float comparison
 # is simple abs(x - y) > EPSILON enough for canvas needs?

--- a/gaphas/solver.py
+++ b/gaphas/solver.py
@@ -429,7 +429,7 @@ class Solver(object):
                     c.mark_dirty(variable)
                     self._marked_cons.append(c)
                     if self._marked_cons.count(c) > 100:
-                        raise JuggleError, 'Variable juggling detected, constraint %s resolved %d times out of %d' % (c, self._marked_cons.count(c), len(self._marked_cons))
+                        raise JuggleError('Variable juggling detected, constraint %s resolved %d times out of %d' % (c, self._marked_cons.count(c), len(self._marked_cons)))
 
 
     @observed

--- a/gaphas/state.py
+++ b/gaphas/state.py
@@ -262,7 +262,7 @@ def getfunction(func):
     Return the function associated with a class method.
     """
     if isinstance(func, types.UnboundMethodType):
-        return func.im_func
+        return func.__func__
     return func
 
 

--- a/gaphas/state.py
+++ b/gaphas/state.py
@@ -19,6 +19,7 @@ set::
 
 """
 
+from builtins import zip
 import types, inspect
 import threading
 from decorator import decorator
@@ -230,7 +231,7 @@ def revert_handler(event):
 
     kw = dict(kwargs)
     kw.update(dict(list(zip(spec[0], args))))
-    for arg, binding in bind.items():
+    for arg, binding in list(bind.items()):
         kw[arg] = saveapply(binding, kw)
     argnames = list(revspec[0])
     if spec[1]: argnames.append(revspec[1])

--- a/gaphas/state.py
+++ b/gaphas/state.py
@@ -229,7 +229,7 @@ def revert_handler(event):
         return
 
     kw = dict(kwargs)
-    kw.update(dict(zip(spec[0], args)))
+    kw.update(dict(list(zip(spec[0], args))))
     for arg, binding in bind.items():
         kw[arg] = saveapply(binding, kw)
     argnames = list(revspec[0])

--- a/gaphas/state.py
+++ b/gaphas/state.py
@@ -230,7 +230,7 @@ def revert_handler(event):
 
     kw = dict(kwargs)
     kw.update(dict(zip(spec[0], args)))
-    for arg, binding in bind.iteritems():
+    for arg, binding in bind.items():
         kw[arg] = saveapply(binding, kw)
     argnames = list(revspec[0])
     if spec[1]: argnames.append(revspec[1])

--- a/gaphas/table.py
+++ b/gaphas/table.py
@@ -107,7 +107,7 @@ class Table(object):
             raise ValueError, "Should either provide a row or a query statement, not both"
         if _row:
             assert len(_row) == len(fields)
-            kv = dict(zip(self._indexes, _row))
+            kv = dict(list(zip(self._indexes, _row)))
 
         rows = list(self.query(**kv))
 

--- a/gaphas/table.py
+++ b/gaphas/table.py
@@ -51,7 +51,7 @@ class Table(object):
         ValueError: Number of arguments doesn't match the number of columns (2 != 3)
         """
         if len(values) != len(self._type._fields):
-            raise ValueError, "Number of arguments doesn't match the number of columns (%d != %d)" % (len(values), len(self._type._fields))
+            raise ValueError("Number of arguments doesn't match the number of columns (%d != %d)" % (len(values), len(self._type._fields)))
         # Add value to index entries
         index = self._index
         data = self._type._make(values)
@@ -104,7 +104,7 @@ class Table(object):
         """
         fields = self._type._fields
         if _row and kv:
-            raise ValueError, "Should either provide a row or a query statement, not both"
+            raise ValueError("Should either provide a row or a query statement, not both")
         if _row:
             assert len(_row) == len(fields)
             kv = dict(list(zip(self._indexes, _row)))

--- a/gaphas/table.py
+++ b/gaphas/table.py
@@ -164,7 +164,7 @@ class Table(object):
             raise AttributeError("Columns %s are not indexed" % str(tuple(bad)))
 
         r = iter([])
-        items = tuple((n, v) for n, v in kv.items() if v is not None)
+        items = tuple((n, v) for n, v in list(kv.items()) if v is not None)
         if all(v in index[n] for n, v in items):
             rows = (index[n][v] for n, v in items)
             try:

--- a/gaphas/table.py
+++ b/gaphas/table.py
@@ -2,6 +2,7 @@
 Table is a storage class that can be used to store information, like
 one would in a database table, with indexes on the desired "columns."
 """
+from functools import reduce
 
 class Table(object):
     """

--- a/gaphas/table.py
+++ b/gaphas/table.py
@@ -169,7 +169,7 @@ class Table(object):
             rows = (index[n][v] for n, v in items)
             try:
                 r = iter(reduce(set.intersection, rows))
-            except TypeError, ex:
+            except TypeError as ex:
                 pass
         return r
 

--- a/gaphas/table.py
+++ b/gaphas/table.py
@@ -2,6 +2,8 @@
 Table is a storage class that can be used to store information, like
 one would in a database table, with indexes on the desired "columns."
 """
+from builtins import str
+from builtins import zip
 from builtins import object
 from functools import reduce
 

--- a/gaphas/table.py
+++ b/gaphas/table.py
@@ -2,6 +2,7 @@
 Table is a storage class that can be used to store information, like
 one would in a database table, with indexes on the desired "columns."
 """
+from builtins import object
 from functools import reduce
 
 class Table(object):

--- a/gaphas/tool.py
+++ b/gaphas/tool.py
@@ -30,7 +30,9 @@ Tools can handle events in different ways
 - event can be ignored
 - tool can handle the event (obviously)
 """
+from __future__ import division
 
+from past.utils import old_div
 __version__ = "$Revision$"
 # $HeadURL$
 
@@ -497,7 +499,7 @@ class PanTool(Tool):
             self.x1, self.y1 = event.x, event.y
             dx = self.x1 - self.x0
             dy = self.y1 - self.y0
-            view._matrix.translate(dx/view._matrix[0], dy/view._matrix[3])
+            view._matrix.translate(old_div(dx,view._matrix[0]), old_div(dy,view._matrix[3]))
             # Make sure everything's updated
             view.request_update((), view._canvas.get_all_items())
             self.x0 = self.x1
@@ -512,13 +514,13 @@ class PanTool(Tool):
         direction = event.direction
         gdk = gtk.gdk
         if direction == gdk.SCROLL_LEFT:
-            view._matrix.translate(self.speed/view._matrix[0], 0)
+            view._matrix.translate(old_div(self.speed,view._matrix[0]), 0)
         elif direction == gdk.SCROLL_RIGHT:
-            view._matrix.translate(-self.speed/view._matrix[0], 0)
+            view._matrix.translate(old_div(-self.speed,view._matrix[0]), 0)
         elif direction == gdk.SCROLL_UP:
-            view._matrix.translate(0, self.speed/view._matrix[3])
+            view._matrix.translate(0, old_div(self.speed,view._matrix[3]))
         elif direction == gdk.SCROLL_DOWN:
-            view._matrix.translate(0, -self.speed/view._matrix[3])
+            view._matrix.translate(0, old_div(-self.speed,view._matrix[3]))
         view.request_update((), view._canvas.get_all_items())
         return True
 
@@ -559,12 +561,12 @@ class ZoomTool(Tool):
 
             sx = view._matrix[0]
             sy = view._matrix[3]
-            ox = (view._matrix[4] - self.x0) / sx
-            oy = (view._matrix[5] - self.y0) / sy
+            ox = old_div((view._matrix[4] - self.x0), sx)
+            oy = old_div((view._matrix[5] - self.y0), sy)
 
             if abs(dy - self.lastdiff) > 20:
                 if dy - self.lastdiff < 0:
-                    factor = 1./0.9
+                    factor = old_div(1.,0.9)
                 else:
                     factor = 0.9
 
@@ -584,11 +586,11 @@ class ZoomTool(Tool):
             view = self.view
             sx = view._matrix[0]
             sy = view._matrix[3]
-            ox = (view._matrix[4] - event.x) / sx
-            oy = (view._matrix[5] - event.y) / sy
+            ox = old_div((view._matrix[4] - event.x), sx)
+            oy = old_div((view._matrix[5] - event.y), sy)
             factor = 0.9
             if event.direction == gtk.gdk.SCROLL_UP:
-                factor = 1. / factor
+                factor = old_div(1., factor)
             view._matrix.translate(-ox, -oy)
             view._matrix.scale(factor, factor)
             view._matrix.translate(+ox, +oy)

--- a/gaphas/tool.py
+++ b/gaphas/tool.py
@@ -33,6 +33,7 @@ Tools can handle events in different ways
 from __future__ import division
 from __future__ import print_function
 
+from builtins import object
 from past.utils import old_div
 __version__ = "$Revision$"
 # $HeadURL$

--- a/gaphas/tool.py
+++ b/gaphas/tool.py
@@ -31,6 +31,7 @@ Tools can handle events in different ways
 - tool can handle the event (obviously)
 """
 from __future__ import division
+from __future__ import print_function
 
 from past.utils import old_div
 __version__ = "$Revision$"
@@ -172,7 +173,7 @@ class ToolChain(Tool):
 
     def grab(self, tool):
         if not self._grabbed_tool:
-            if DEBUG_TOOL_CHAIN: print 'Grab tool', tool
+            if DEBUG_TOOL_CHAIN: print('Grab tool', tool)
             # Send grab event
             event = Event(type=Tool.GRAB)
             tool.handle(event)
@@ -180,7 +181,7 @@ class ToolChain(Tool):
 
     def ungrab(self, tool):
         if self._grabbed_tool is tool:
-            if DEBUG_TOOL_CHAIN: print 'UNgrab tool', self._grabbed_tool
+            if DEBUG_TOOL_CHAIN: print('UNgrab tool', self._grabbed_tool)
             # Send ungrab event
             event = Event(type=Tool.UNGRAB)
             tool.handle(event)
@@ -214,7 +215,7 @@ class ToolChain(Tool):
                     self.ungrab(self._grabbed_tool)
         else:
             for tool in self._tools:
-                if DEBUG_TOOL_CHAIN: print 'tool', tool
+                if DEBUG_TOOL_CHAIN: print('tool', tool)
                 rt = tool.handle(event)
                 if rt:
                     if event.type == gtk.gdk.BUTTON_PRESS:

--- a/gaphas/tree.py
+++ b/gaphas/tree.py
@@ -2,6 +2,7 @@
 Simple class containing the tree structure for the canvas items.
 """
 
+from builtins import map
 from builtins import object
 from builtins import range
 __version__ = "$Revision$"
@@ -182,7 +183,7 @@ class Tree(object):
         """
         nodes = self.nodes
         lnodes = len(nodes)
-        list(map(setattr, nodes, [index_key] * lnodes, range(lnodes)))
+        list(map(setattr, nodes, [index_key] * lnodes, list(range(lnodes))))
 
     def sort(self, nodes, index_key, reverse=False):
         """

--- a/gaphas/tree.py
+++ b/gaphas/tree.py
@@ -180,7 +180,7 @@ class Tree(object):
         """
         nodes = self.nodes
         lnodes = len(nodes)
-        map(setattr, nodes, [index_key] * lnodes, xrange(lnodes))
+        list(map(setattr, nodes, [index_key] * lnodes, xrange(lnodes)))
 
     def sort(self, nodes, index_key, reverse=False):
         """

--- a/gaphas/tree.py
+++ b/gaphas/tree.py
@@ -2,6 +2,7 @@
 Simple class containing the tree structure for the canvas items.
 """
 
+from builtins import range
 __version__ = "$Revision$"
 # $HeadURL$
 
@@ -180,7 +181,7 @@ class Tree(object):
         """
         nodes = self.nodes
         lnodes = len(nodes)
-        list(map(setattr, nodes, [index_key] * lnodes, xrange(lnodes)))
+        list(map(setattr, nodes, [index_key] * lnodes, range(lnodes)))
 
     def sort(self, nodes, index_key, reverse=False):
         """

--- a/gaphas/tree.py
+++ b/gaphas/tree.py
@@ -2,6 +2,7 @@
 Simple class containing the tree structure for the canvas items.
 """
 
+from builtins import object
 from builtins import range
 __version__ = "$Revision$"
 # $HeadURL$

--- a/gaphas/util.py
+++ b/gaphas/util.py
@@ -2,7 +2,9 @@
 Helper functions and classes for Cairo (drawing engine used by the
 canvas).
 """
+from __future__ import division
 
+from past.utils import old_div
 __version__ = "$Revision$"
 # $HeadURL$
 
@@ -54,13 +56,13 @@ def text_align(cr, x, y, text, align_x=0, align_y=0, padding_x=0, padding_y=0):
 
     x_bear, y_bear, w, h, x_adv, y_adv = cr.text_extents(text)
     if align_x == 0:
-        x = 0.5 - (w / 2 + x_bear) + x
+        x = 0.5 - (old_div(w, 2) + x_bear) + x
     elif align_x < 0:
         x = - (w + x_bear) + x - padding_x
     else:
         x = x + padding_x
     if align_y == 0:
-        y = 0.5 - (h / 2 + y_bear) + y
+        y = 0.5 - (old_div(h, 2) + y_bear) + y
     elif align_y < 0:
         y = - (h + y_bear) + y - padding_y
     else:
@@ -127,7 +129,7 @@ def path_ellipse (cr, x, y, width, height, angle=0):
     cr.save()
     cr.translate (x, y)
     cr.rotate (angle)
-    cr.scale (width / 2.0, height / 2.0)
+    cr.scale (old_div(width, 2.0), old_div(height, 2.0))
     cr.move_to(1.0, 0.0)
     cr.arc (0.0, 0.0, 1.0, 0.0, 2.0 * pi)
     cr.restore()

--- a/gaphas/view.py
+++ b/gaphas/view.py
@@ -2,7 +2,9 @@
 This module contains everything to display a Canvas on a screen.
 """
 from __future__ import absolute_import
+from __future__ import division
 
+from past.utils import old_div
 __version__ = "$Revision$"
 # $HeadURL$
 
@@ -644,9 +646,9 @@ class GtkView(gtk.DrawingArea, View):
 
         # set increments
         hadjustment.page_increment = aw
-        hadjustment.step_increment = aw / 10
+        hadjustment.step_increment = old_div(aw, 10)
         vadjustment.page_increment = ah
-        vadjustment.step_increment = ah / 10
+        vadjustment.step_increment = old_div(ah, 10)
 
         # set position
         if v.x != hadjustment.value or v.y != vadjustment.value:

--- a/gaphas/view.py
+++ b/gaphas/view.py
@@ -4,6 +4,7 @@ This module contains everything to display a Canvas on a screen.
 from __future__ import absolute_import
 from __future__ import division
 
+from builtins import map
 from builtins import object
 from past.utils import old_div
 __version__ = "$Revision$"

--- a/gaphas/view.py
+++ b/gaphas/view.py
@@ -1,6 +1,7 @@
 """
 This module contains everything to display a Canvas on a screen.
 """
+from __future__ import absolute_import
 
 __version__ = "$Revision$"
 # $HeadURL$
@@ -10,13 +11,13 @@ pygtk.require('2.0')
 import gobject
 import gtk
 from cairo import Matrix
-from canvas import Context
-from geometry import Rectangle, distance_point_point_fast
-from quadtree import Quadtree
-from tool import DefaultTool
-from painter import DefaultPainter, BoundingBoxPainter
-from decorators import async, PRIORITY_HIGH_IDLE
-from decorators import nonrecursive
+from .canvas import Context
+from .geometry import Rectangle, distance_point_point_fast
+from .quadtree import Quadtree
+from .tool import DefaultTool
+from .painter import DefaultPainter, BoundingBoxPainter
+from .decorators import async, PRIORITY_HIGH_IDLE
+from .decorators import nonrecursive
 
 # Handy debug flag for drawing bounding boxes around the items.
 DEBUG_DRAW_BOUNDING_BOX = False

--- a/gaphas/view.py
+++ b/gaphas/view.py
@@ -5,6 +5,8 @@ This module contains everything to display a Canvas on a screen.
 __version__ = "$Revision$"
 # $HeadURL$
 
+import pygtk
+pygtk.require('2.0')
 import gobject
 import gtk
 from cairo import Matrix

--- a/gaphas/view.py
+++ b/gaphas/view.py
@@ -357,7 +357,7 @@ class View(object):
         rectangle @rect.
         """
         items = self._qtree.find_inside(rect)
-        map(self.select_item, items)
+        list(map(self.select_item, items))
 
 
     def zoom(self, factor):

--- a/gaphas/view.py
+++ b/gaphas/view.py
@@ -4,6 +4,7 @@ This module contains everything to display a Canvas on a screen.
 from __future__ import absolute_import
 from __future__ import division
 
+from builtins import object
 from past.utils import old_div
 __version__ = "$Revision$"
 # $HeadURL$

--- a/gaphas/view.py
+++ b/gaphas/view.py
@@ -662,7 +662,7 @@ class GtkView(gtk.DrawingArea, View):
         redrawal?
         """
         get_bounds = self._qtree.get_bounds
-        items = filter(None, items)
+        items = [_f for _f in items if _f]
         try:
             # create a copy, otherwise we'll change the original rectangle
             bounds = Rectangle(*get_bounds(items[0]))

--- a/gaphas/weakset.py
+++ b/gaphas/weakset.py
@@ -6,11 +6,12 @@ distribution, this file is licensed under the Python Software
 Foundation License, version 2.
 """
 
+from builtins import object
 from _weakref import ref
 
 __all__ = ['WeakSet']
 
-class WeakSet:
+class WeakSet(object):
     def __init__(self, data=None):
         self.data = set()
         def _remove(item, selfref=ref(self)):


### PR DESCRIPTION
This contribution is part of a larger effort to update Gaphor, Gaphas, and etk.docking to support Python 2.7, 3.5, 3.6, and 3.7 and PyGObject which replaces PyGTK. I would also like to eventually incrementally replace Gtk+ with the Toga native cross-platform GUI toolkit.

This PR used Futurize to do the conversion to support Python 2.7 and Python 3.