### PR TITLE
fix(guide,view): Proper access to view allocation

### DIFF
--- a/gaphas/guide.py
+++ b/gaphas/guide.py
@@ -160,7 +160,7 @@ class GuideMixin(object):
 
     def get_view_dimensions(self):
         try:
-            allocation = self.view.allocation
+            allocation = self.view.get_allocation()
         except AttributeError as e:
             return 0, 0
         return allocation.width, allocation.height

--- a/gaphas/view.py
+++ b/gaphas/view.py
@@ -714,7 +714,7 @@ class GtkView(Gtk.DrawingArea, Gtk.Scrollable, View):
             super(GtkView, self).queue_draw_area(int(x), int(y), int(w+1), int(h+1))
         except OverflowError:
             # Okay, now the zoom factor is very large or something
-            a = self.allocation
+            a = self.get_allocation()
             super(GtkView, self).queue_draw_area(0, 0, a.width, a.height)
 
 


### PR DESCRIPTION
The access to the allocation of a `GtkView` in GTK+ 3 is via `get_allocation()`, not `allocation`