### PR TITLE
fix(view): Handle item_distance == 0 correctly

### DIFF
--- a/gaphas/view.py
+++ b/gaphas/view.py
@@ -241,7 +241,7 @@ class View(object):
             v2i = self.get_matrix_v2i(item)
             ix, iy = v2i.transform_point(*pos)
             item_distance = item.point((ix, iy))
-            if item_distance and item_distance < 0.5:
+            if item_distance < 0.5:
                 return item
         return None
 


### PR DESCRIPTION
In `get_item_at_point` of the `View` class the `item_distance` was calculated. The result of this calculation can be exactly 0. Yet, 0 is considered as `False` in an boolean expression, which is why

```python
            if item_distance and item_distance < 0.5:
                return item
```

did not return `item` in that case.

`item_distance` cannot be `None` I think, so this extra check should be obsolete and I removed it. If it can be `None`, please replace the line by `if item_distance is not None and item_distance < 0.5:`