### PR TITLE
Remove Usage of Future old_div, Cleanup Imports, and Remove use of __version__ on Modules

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,4 +3,4 @@ repos:
     rev: stable
     hooks:
     - id: black
-      language_version: python3.7
+      language_version: python3

--- a/demo.py
+++ b/demo.py
@@ -14,12 +14,8 @@ It sports a small canvas and some trivial operations:
 
 """
 
-try:
-    import gi
-except ImportError:
-    pass
-else:
-    gi.require_version("Gtk", "3.0")
+import gi
+gi.require_version("Gtk", "3.0")
 
 import math
 

--- a/demo.py
+++ b/demo.py
@@ -15,6 +15,7 @@ It sports a small canvas and some trivial operations:
 """
 
 import gi
+
 gi.require_version("Gtk", "3.0")
 
 import math

--- a/demo.py
+++ b/demo.py
@@ -14,9 +14,6 @@ It sports a small canvas and some trivial operations:
 
 """
 
-__version__ = "$Revision$"
-# $HeadURL$
-
 try:
     import gi
 except ImportError:
@@ -25,14 +22,15 @@ else:
     gi.require_version("Gtk", "3.0")
 
 import math
-from gi.repository import Gtk
+
 import cairo
+from gi.repository import Gtk
+
 from gaphas import Canvas, GtkView, View
+from gaphas import state
 from gaphas.examples import Box, PortoBox, Text, FatLine, Circle
-from gaphas.item import Line, NW, SE
-from gaphas.tool import PlacementTool, HandleTool
-from gaphas.segment import Segment
-import gaphas.guide
+from gaphas.freehand import FreeHandPainter
+from gaphas.item import Line
 from gaphas.painter import (
     PainterChain,
     ItemPainter,
@@ -41,11 +39,9 @@ from gaphas.painter import (
     ToolPainter,
     BoundingBoxPainter,
 )
-from gaphas import state
+from gaphas.segment import Segment
+from gaphas.tool import PlacementTool, HandleTool
 from gaphas.util import text_extents, text_underline
-from gaphas.freehand import FreeHandPainter
-
-from gaphas import painter
 
 # painter.DEBUG_DRAW_BOUNDING_BOX = True
 

--- a/gaphas/aspect.py
+++ b/gaphas/aspect.py
@@ -12,12 +12,9 @@ from __future__ import absolute_import
 
 from builtins import object
 
-import gi
-
-gi.require_version("Gdk", "3.0")
 from gi.repository import Gdk
-
 from simplegeneric import generic
+
 from gaphas.item import Item, Element
 
 

--- a/gaphas/canvas.py
+++ b/gaphas/canvas.py
@@ -28,24 +28,20 @@ To get connecting items (i.e. all lines connected to a class)::
 """
 from __future__ import absolute_import
 
-from builtins import next
+import logging
 from builtins import map
+from builtins import next
 from builtins import object
 from builtins import range
-
-__version__ = "$Revision$"
-# $HeadURL$
-
 from collections import namedtuple
-import logging
 
 from cairo import Matrix
-from gaphas import tree
+
 from gaphas import solver
 from gaphas import table
+from gaphas import tree
 from gaphas.decorators import nonrecursive, AsyncIO
 from .state import observed, reversible_method, reversible_pair
-
 
 #
 # Information about two connected items

--- a/gaphas/constraint.py
+++ b/gaphas/constraint.py
@@ -37,11 +37,6 @@ import math
 
 from gaphas.solver import Projection
 
-
-__version__ = "$Revision$"
-# $HeadURL$
-
-
 # is simple abs(x - y) > EPSILON enough for canvas needs?
 EPSILON = 1e-6
 

--- a/gaphas/decorators.py
+++ b/gaphas/decorators.py
@@ -3,19 +3,13 @@ Custom decorators.
 """
 from __future__ import print_function
 
+import threading
 from builtins import object
 
-__version__ = "$Revision$"
-# $HeadURL$
-
-import threading
 import gi
 
 gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk, GLib
-
-# from GLib import PRIORITY_HIGH, PRIORITY_HIGH_IDLE, PRIORITY_DEFAULT, \
-#         PRIORITY_DEFAULT_IDLE, PRIORITY_LOW
 
 
 DEBUG_ASYNC = False

--- a/gaphas/decorators.py
+++ b/gaphas/decorators.py
@@ -6,11 +6,7 @@ from __future__ import print_function
 import threading
 from builtins import object
 
-import gi
-
-gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk, GLib
-
 
 DEBUG_ASYNC = False
 

--- a/gaphas/examples.py
+++ b/gaphas/examples.py
@@ -5,16 +5,13 @@ These items are used in various tests.
 from __future__ import absolute_import
 from __future__ import division
 
-from past.utils import old_div
+from gaphas.connector import Handle, PointPort, LinePort, Position
+from gaphas.item import Element, Item, NW, NE, SW, SE
+from gaphas.solver import WEAK
+from .util import text_align, text_multiline, path_ellipse
 
 __version__ = "$Revision$"
 # $HeadURL$
-
-from gaphas.item import Element, Item, NW, NE, SW, SE
-from gaphas.connector import Handle, PointPort, LinePort, Position
-from gaphas.solver import solvable, WEAK
-from . import tool
-from .util import text_align, text_multiline, path_ellipse
 
 
 class Box(Element):
@@ -73,7 +70,7 @@ class PortoBox(Box):
 
         # handle for movable port
         self._hm = Handle(strength=WEAK)
-        self._hm.pos = width, old_div(height, 2.0)
+        self._hm.pos = width, height / 2.0
         self._handles.append(self._hm)
 
         # movable port
@@ -85,7 +82,7 @@ class PortoBox(Box):
         self.constraint(above=(self._hm.pos, se.pos))
 
         # static point port
-        self._sport = PointPort(Position((old_div(width, 2.0), height)))
+        self._sport = PointPort(Position((width / 2.0, height)))
         l = sw.pos, se.pos
         self.constraint(line=(self._sport.point, l))
         self._ports.append(self._sport)

--- a/gaphas/examples.py
+++ b/gaphas/examples.py
@@ -10,9 +10,6 @@ from gaphas.item import Element, Item, NW, NE, SW, SE
 from gaphas.solver import WEAK
 from .util import text_align, text_multiline, path_ellipse
 
-__version__ = "$Revision$"
-# $HeadURL$
-
 
 class Box(Element):
     """ A Box has 4 handles (for a start):

--- a/gaphas/geometry.py
+++ b/gaphas/geometry.py
@@ -444,7 +444,7 @@ def intersect_line_line(line1_start, line1_end, line2_start, line2_end):
     """
     Find the point where the lines (segments) defined by
     ``(line1_start, line1_end)`` and ``(line2_start, line2_end)``
-    intersect.  If no intersecion occurs, ``None`` is returned.
+    intersect.  If no intersection occurs, ``None`` is returned.
 
     >>> intersect_line_line((3, 0), (8, 10), (0, 0), (10, 10))
     (6, 6)
@@ -493,7 +493,7 @@ def intersect_line_line(line1_start, line1_end, line2_start, line2_end):
     #        DO_INTERSECT      1
     #        COLLINEAR         2
     #
-    # Error condititions:
+    # Error conditions:
     #
     #     Depending upon the possible ranges, and particularly on 16-bit
     #     computers, care should be taken to protect from overflow.
@@ -548,22 +548,23 @@ def intersect_line_line(line1_start, line1_end, line2_start, line2_end):
         return None  # ( DONT_INTERSECT )
 
     # Line segments intersect: compute intersection point.
-
-    denom = a1 * b2 - a2 * b1
-    if not denom:
-        return None  # ( COLLINEAR )
-    offset = abs(denom) / 2
-
-    # The denom/2 is to get rounding instead of truncating.  It
+    # The denom / 2 is to get rounding instead of truncating.  It
     # is added or subtracted to the numerator, depending upon the
     # sign of the numerator.
 
-    num = b1 * c2 - b2 * c1
-    x = ((num < 0) and (num - offset) or (num + offset)) / denom
-
-    num = a2 * c1 - a1 * c2
-    y = ((num < 0) and (num - offset) or (num + offset)) / denom
-
+    denom = a1 * b2 - a2 * b1
+    x_num = b1 * c2 - b2 * c1
+    y_num = a2 * c1 - a1 * c2
+    if not denom:
+        return None  # ( COLLINEAR )
+    elif isinstance(denom, float):  # denom is float, use normal division
+        offset = abs(denom) / 2
+        x = ((x_num < 0) and (x_num - offset) or (x_num + offset)) / denom
+        y = ((y_num < 0) and (y_num - offset) or (y_num + offset)) / denom
+    else:  # denom is int, use integer division
+        offset = abs(denom) // 2
+        x = ((x_num < 0) and (x_num - offset) or (x_num + offset)) // denom
+        y = ((y_num < 0) and (y_num - offset) or (y_num + offset)) // denom
     return x, y
 
 

--- a/gaphas/geometry.py
+++ b/gaphas/geometry.py
@@ -10,7 +10,6 @@ A point is represented as a tuple `(x, y)`.
 from __future__ import division
 
 from builtins import object
-from past.utils import old_div
 
 __version__ = "$Revision$"
 # $HeadURL$
@@ -382,12 +381,12 @@ def point_on_rectangle(rect, point, border=False):
     if x_inside and y_inside:
         # Find point on side closest to the point
         if min(abs(rx - px), abs(rx + rw - px)) > min(abs(ry - py), abs(ry + rh - py)):
-            if py < ry + old_div(rh, 2.0):
+            if py < ry + rh / 2.0:
                 py = ry
             else:
                 py = ry + rh
         else:
-            if px < rx + old_div(rw, 2.0):
+            if px < rx + rw / 2.0:
                 px = rx
             else:
                 px = rx + rw
@@ -427,7 +426,7 @@ def distance_line_point(line_start, line_end, point):
     if line_len_sqr < 0.0001:
         return distance_point_point(point), line_start
 
-    projlen = old_div((line_end[0] * point[0] + line_end[1] * point[1]), line_len_sqr)
+    projlen = (line_end[0] * point[0] + line_end[1] * point[1]) / line_len_sqr
 
     if projlen < 0.0:
         # Closest point is the start of the line.
@@ -557,17 +556,17 @@ def intersect_line_line(line1_start, line1_end, line2_start, line2_end):
     denom = a1 * b2 - a2 * b1
     if not denom:
         return None  # ( COLLINEAR )
-    offset = old_div(abs(denom), 2)
+    offset = abs(denom) / 2
 
     # The denom/2 is to get rounding instead of truncating.  It
     # is added or subtracted to the numerator, depending upon the
     # sign of the numerator.
 
     num = b1 * c2 - b2 * c1
-    x = old_div(((num < 0) and (num - offset) or (num + offset)), denom)
+    x = ((num < 0) and (num - offset) or (num + offset)) / denom
 
     num = a2 * c1 - a1 * c2
-    y = old_div(((num < 0) and (num - offset) or (num + offset)), denom)
+    y = ((num < 0) and (num - offset) or (num + offset)) / denom
 
     return x, y
 

--- a/gaphas/geometry.py
+++ b/gaphas/geometry.py
@@ -10,10 +10,6 @@ A point is represented as a tuple `(x, y)`.
 from __future__ import division
 
 from builtins import object
-
-__version__ = "$Revision$"
-# $HeadURL$
-
 from math import sqrt
 
 

--- a/gaphas/guide.py
+++ b/gaphas/guide.py
@@ -5,13 +5,13 @@ from __future__ import division
 
 from builtins import map
 from builtins import object
-from past.utils import old_div
+from functools import reduce
+
 from simplegeneric import generic
+
 from gaphas.aspect import InMotion, HandleInMotion, PaintFocused
 from gaphas.aspect import ItemInMotion, ItemHandleInMotion, ItemPaintFocused
-from gaphas.connector import Handle
-from gaphas.item import Item, Element, Line, SE
-from functools import reduce
+from gaphas.item import Item, Element, Line
 
 
 class ItemGuide(object):
@@ -42,11 +42,11 @@ Guide = generic(ItemGuide)
 class ElementGuide(ItemGuide):
     def horizontal(self):
         y = self.item.height
-        return (0, old_div(y, 2), y)
+        return (0, y / 2, y)
 
     def vertical(self):
         x = self.item.width
-        return (0, old_div(x, 2), x)
+        return (0, x / 2, x)
 
 
 @Guide.when_type(Line)

--- a/gaphas/item.py
+++ b/gaphas/item.py
@@ -3,17 +3,13 @@ Basic items.
 """
 from __future__ import absolute_import
 
-from builtins import zip
 from builtins import map
 from builtins import object
 from builtins import range
-
-__version__ = "$Revision$"
-# $HeadURL$
-
+from builtins import zip
+from functools import reduce
 from math import atan2
 from weakref import WeakKeyDictionary
-from functools import reduce
 
 try:
     # python 3.0 (better be prepared)
@@ -24,7 +20,7 @@ except ImportError:
 from .matrix import Matrix
 from .geometry import distance_line_point, distance_rectangle_point
 from .connector import Handle, LinePort
-from .solver import solvable, WEAK, NORMAL, STRONG, VERY_STRONG, REQUIRED
+from .solver import solvable, WEAK, VERY_STRONG, REQUIRED
 from .constraint import (
     EqualsConstraint,
     LessThanConstraint,

--- a/gaphas/matrix.py
+++ b/gaphas/matrix.py
@@ -11,7 +11,6 @@ from __future__ import absolute_import
 from __future__ import division
 
 from builtins import object
-from past.utils import old_div
 
 __version__ = "$Revision$"
 # $HeadURL$
@@ -60,7 +59,7 @@ class Matrix(object):
     reversible_method(invert, invert)
     reversible_method(rotate, rotate, {"radians": lambda radians: -radians})
     reversible_method(
-        scale, scale, {"sx": lambda sx: old_div(1, sx), "sy": lambda sy: old_div(1, sy)}
+        scale, scale, {"sx": lambda sx: 1 / sx, "sy": lambda sy: 1 / sy}
     )
     reversible_method(
         translate, translate, {"tx": lambda tx: -tx, "ty": lambda ty: -ty}

--- a/gaphas/matrix.py
+++ b/gaphas/matrix.py
@@ -58,9 +58,7 @@ class Matrix(object):
 
     reversible_method(invert, invert)
     reversible_method(rotate, rotate, {"radians": lambda radians: -radians})
-    reversible_method(
-        scale, scale, {"sx": lambda sx: 1 / sx, "sy": lambda sy: 1 / sy}
-    )
+    reversible_method(scale, scale, {"sx": lambda sx: 1 / sx, "sy": lambda sy: 1 / sy})
     reversible_method(
         translate, translate, {"tx": lambda tx: -tx, "ty": lambda ty: -ty}
     )

--- a/gaphas/painter.py
+++ b/gaphas/painter.py
@@ -9,7 +9,6 @@ and handles).
 from __future__ import division
 
 from builtins import object
-from past.utils import old_div
 
 __version__ = "$Revision$"
 # $HeadURL$
@@ -197,7 +196,7 @@ class CairoBoundingBoxContext(object):
         cr.restore()
         if b and line_width:
             # Do this after the restore(), so we can get the proper width.
-            lw = old_div(cr.get_line_width(), 2)
+            lw = cr.get_line_width() / 2
             d = cr.user_to_device_distance(lw, lw)
             b.expand(d[0] + d[1])
         self._update_bounds(b)
@@ -333,7 +332,7 @@ class HandlePainter(Painter):
                 cairo.move_to(2, -2)
                 cairo.line_to(-2, 3)
             cairo.set_source_rgba(
-                old_div(r, 4.0), old_div(g, 4.0), old_div(b, 4.0), opacity * 1.3
+                r / 4.0, g / 4.0, b / 4.0, opacity * 1.3
             )
             cairo.stroke()
         cairo.restore()

--- a/gaphas/painter.py
+++ b/gaphas/painter.py
@@ -331,9 +331,7 @@ class HandlePainter(Painter):
                 cairo.line_to(2, 3)
                 cairo.move_to(2, -2)
                 cairo.line_to(-2, 3)
-            cairo.set_source_rgba(
-                r / 4.0, g / 4.0, b / 4.0, opacity * 1.3
-            )
+            cairo.set_source_rgba(r / 4.0, g / 4.0, b / 4.0, opacity * 1.3)
             cairo.stroke()
         cairo.restore()
 

--- a/gaphas/quadtree.py
+++ b/gaphas/quadtree.py
@@ -28,9 +28,6 @@ from builtins import zip
 
 from .geometry import rectangle_contains, rectangle_intersects, rectangle_clip
 
-__version__ = "$Revision$"
-# $HeadURL$
-
 
 class Quadtree(object):
     """

--- a/gaphas/quadtree.py
+++ b/gaphas/quadtree.py
@@ -21,16 +21,15 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-from builtins import zip
+import operator
 from builtins import map
 from builtins import object
-from past.utils import old_div
+from builtins import zip
+
+from .geometry import rectangle_contains, rectangle_intersects, rectangle_clip
 
 __version__ = "$Revision$"
 # $HeadURL$
-
-import operator
-from .geometry import rectangle_contains, rectangle_intersects, rectangle_clip
 
 
 class Quadtree(object):
@@ -298,7 +297,7 @@ class QuadtreeBucket(object):
         # create new subnodes if threshold is reached
         if not self._buckets and len(self.items) >= self.capacity:
             x, y, w, h = self.bounds
-            rw, rh = old_div(w, 2.0), old_div(h, 2.0)
+            rw, rh = w / 2.0, h / 2.0
             cx, cy = x + rw, y + rh
             self._buckets = [
                 QuadtreeBucket((x, y, rw, rh), self.capacity),
@@ -341,7 +340,7 @@ class QuadtreeBucket(object):
         """
         if self._buckets:
             sx, sy, sw, sh = self.bounds
-            cx, cy = sx + old_div(sw, 2.0), sy + old_div(sh, 2.0)
+            cx, cy = sx + sw / 2.0, sy + sh / 2.0
             x, y, w, h = bounds
             index = 0
             if x >= cx:

--- a/gaphas/segment.py
+++ b/gaphas/segment.py
@@ -66,9 +66,7 @@ class LineSegment(object):
             p0 = handles[segment].pos
             p1 = handles[segment + 1].pos
             dx, dy = p1.x - p0.x, p1.y - p0.y
-            new_h = item._create_handle(
-                (p0.x + dx / count, p0.y + dy / count)
-            )
+            new_h = item._create_handle((p0.x + dx / count, p0.y + dy / count))
             item._reversible_insert_handle(segment + 1, new_h)
 
             p0 = item._create_port(p0, new_h.pos)

--- a/gaphas/segment.py
+++ b/gaphas/segment.py
@@ -3,16 +3,17 @@ Allow for easily adding segments to lines.
 """
 from __future__ import division
 
-from builtins import zip
 from builtins import object
-from past.utils import old_div
+from builtins import zip
+
 from cairo import Matrix, ANTIALIAS_NONE
 from simplegeneric import generic
+
+from gaphas.aspect import ConnectionSink
+from gaphas.aspect import HandleFinder, HandleSelection, PaintFocused
+from gaphas.aspect import ItemHandleFinder, ItemHandleSelection, ItemPaintFocused
 from gaphas.geometry import distance_point_point_fast, distance_line_point
 from gaphas.item import Line
-from gaphas.aspect import HandleFinder, HandleSelection, PaintFocused
-from gaphas.aspect import ConnectionSink
-from gaphas.aspect import ItemHandleFinder, ItemHandleSelection, ItemPaintFocused
 
 
 @generic
@@ -32,8 +33,8 @@ class LineSegment(object):
         handles = item.handles()
         x, y = self.view.get_matrix_v2i(item).transform_point(*pos)
         for h1, h2 in zip(handles, handles[1:]):
-            xp = old_div((h1.pos.x + h2.pos.x), 2)
-            yp = old_div((h1.pos.y + h2.pos.y), 2)
+            xp = (h1.pos.x + h2.pos.x) / 2
+            yp = (h1.pos.y + h2.pos.y) / 2
             if distance_point_point_fast((x, y), (xp, yp)) <= 4:
                 segment = handles.index(h1)
                 handles, ports = self.split_segment(segment)
@@ -66,7 +67,7 @@ class LineSegment(object):
             p1 = handles[segment + 1].pos
             dx, dy = p1.x - p0.x, p1.y - p0.y
             new_h = item._create_handle(
-                (p0.x + old_div(dx, count), p0.y + old_div(dy, count))
+                (p0.x + dx / count, p0.y + dy / count)
             )
             item._reversible_insert_handle(segment + 1, new_h)
 
@@ -249,8 +250,8 @@ class LineSegmentPainter(ItemPaintFocused):
             h = item.handles()
             for h1, h2 in zip(h[:-1], h[1:]):
                 p1, p2 = h1.pos, h2.pos
-                cx = old_div((p1.x + p2.x), 2)
-                cy = old_div((p1.y + p2.y), 2)
+                cx = (p1.x + p2.x) / 2
+                cy = (p1.y + p2.y) / 2
                 cr.save()
                 cr.identity_matrix()
                 m = Matrix(*view.get_matrix_i2v(item))

--- a/gaphas/solver.py
+++ b/gaphas/solver.py
@@ -34,13 +34,10 @@ every constraint is being asked to solve itself
 variables to make the constraint valid again.
 """
 
-from __future__ import division
 from __future__ import absolute_import
+from __future__ import division
 
 from builtins import object
-
-__version__ = "$Revision$"
-# $HeadURL$
 
 from .state import observed, reversible_pair, reversible_property
 

--- a/gaphas/tests/test_solver.py
+++ b/gaphas/tests/test_solver.py
@@ -4,7 +4,6 @@ Unit tests for Gaphas' solver.
 from __future__ import print_function
 from __future__ import division
 
-from past.utils import old_div
 import unittest
 from timeit import Timer
 
@@ -159,7 +158,7 @@ c_eq.weakest()""",
 
         # Print the average of the best 10 runs:
         results.sort()
-        print("[Avg: %gms]" % ((old_div(sum(results[:10]), 10)) * 1000))
+        print("[Avg: %gms]" % ((sum(results[:10]) / 10)) * 1000)
 
 
 if __name__ == "__main__":

--- a/gaphas/tests/test_view.py
+++ b/gaphas/tests/test_view.py
@@ -7,7 +7,6 @@ import math
 import unittest
 
 from gi.repository import Gtk
-from past.utils import old_div
 
 from gaphas.canvas import Canvas
 from gaphas.examples import Box
@@ -113,7 +112,7 @@ class ViewTestCase(unittest.TestCase):
         box.min_width = 20
         box.min_height = 30
         box.matrix.translate(20, 20)
-        box.matrix.rotate(old_div(math.pi, 1.5))
+        box.matrix.rotate(math.pi / 1.5)
         canvas.add(box)
 
         i, h = view.get_handle_at_point((20, 20))
@@ -131,7 +130,7 @@ class ViewTestCase(unittest.TestCase):
         box.min_width = 20
         box.min_height = 30
         box.matrix.translate(20, 20)
-        box.matrix.rotate(old_div(math.pi, 2))
+        box.matrix.rotate(math.pi / 2)
         canvas.add(box)
 
         p = canvas.get_matrix_i2c(box).transform_point(0, 20)

--- a/gaphas/tool.py
+++ b/gaphas/tool.py
@@ -35,12 +35,8 @@ from __future__ import print_function
 
 from builtins import object
 
-import gi
-
-gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk, Gdk
 
-from gaphas.canvas import Context
 from gaphas.aspect import (
     Finder,
     Selection,
@@ -50,7 +46,7 @@ from gaphas.aspect import (
     HandleInMotion,
     Connector,
 )
-
+from gaphas.canvas import Context
 
 DEBUG_TOOL_CHAIN = False
 

--- a/gaphas/tool.py
+++ b/gaphas/tool.py
@@ -510,9 +510,7 @@ class PanTool(Tool):
             self.x1, self.y1 = event.get_coords()[1:]
             dx = self.x1 - self.x0
             dy = self.y1 - self.y0
-            view._matrix.translate(
-                dx / view._matrix[0], dy / view._matrix[3]
-            )
+            view._matrix.translate(dx / view._matrix[0], dy / view._matrix[3])
             # Make sure everything's updated
             view.request_update((), view._canvas.get_all_items())
             self.x0 = self.x1

--- a/gaphas/tool.py
+++ b/gaphas/tool.py
@@ -35,9 +35,6 @@ from __future__ import print_function
 
 from builtins import object
 
-__version__ = "$Revision$"
-# $HeadURL$
-
 import gi
 
 gi.require_version("Gtk", "3.0")

--- a/gaphas/tool.py
+++ b/gaphas/tool.py
@@ -34,14 +34,9 @@ from __future__ import division
 from __future__ import print_function
 
 from builtins import object
-from past.utils import old_div
 
 __version__ = "$Revision$"
 # $HeadURL$
-
-import sys
-
-import cairo
 
 import gi
 
@@ -49,9 +44,6 @@ gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk, Gdk
 
 from gaphas.canvas import Context
-from gaphas.geometry import Rectangle
-from gaphas.geometry import distance_point_point_fast, distance_line_point
-from gaphas.item import Line
 from gaphas.aspect import (
     Finder,
     Selection,
@@ -526,7 +518,7 @@ class PanTool(Tool):
             dx = self.x1 - self.x0
             dy = self.y1 - self.y0
             view._matrix.translate(
-                old_div(dx, view._matrix[0]), old_div(dy, view._matrix[3])
+                dx / view._matrix[0], dy / view._matrix[3]
             )
             # Make sure everything's updated
             view.request_update((), view._canvas.get_all_items())
@@ -541,13 +533,13 @@ class PanTool(Tool):
         view = self.view
         direction = get_scroll_direction()[1]
         if direction == Gdk.ScrollDirection.LEFT:
-            view._matrix.translate(old_div(self.speed, view._matrix[0]), 0)
+            view._matrix.translate(self.speed / view._matrix[0], 0)
         elif direction == Gdk.ScrollDirection.RIGHT:
-            view._matrix.translate(old_div(-self.speed, view._matrix[0]), 0)
+            view._matrix.translate(-self.speed / view._matrix[0], 0)
         elif direction == Gdk.ScrollDirection.UP:
-            view._matrix.translate(0, old_div(self.speed, view._matrix[3]))
+            view._matrix.translate(0, self.speed / view._matrix[3])
         elif direction == Gdk.ScrollDirection.DOWN:
-            view._matrix.translate(0, old_div(-self.speed, view._matrix[3]))
+            view._matrix.translate(0, -self.speed / view._matrix[3])
         view.request_update((), view._canvas.get_all_items())
         return True
 
@@ -599,12 +591,12 @@ class ZoomTool(Tool):
 
             sx = view._matrix[0]
             sy = view._matrix[3]
-            ox = old_div((view._matrix[4] - self.x0), sx)
-            oy = old_div((view._matrix[5] - self.y0), sy)
+            ox = (view._matrix[4] - self.x0) / sx
+            oy = (view._matrix[5] - self.y0) / sy
 
             if abs(dy - self.lastdiff) > 20:
                 if dy - self.lastdiff < 0:
-                    factor = old_div(1.0, 0.9)
+                    factor = 1.0 / 0.9
                 else:
                     factor = 0.9
 
@@ -625,11 +617,11 @@ class ZoomTool(Tool):
             sx = view._matrix[0]
             sy = view._matrix[3]
             pos = event.get_coords()[1:]
-            ox = old_div((view._matrix[4] - pos[0]), sx)
-            oy = old_div((view._matrix[5] - pos[1]), sy)
+            ox = (view._matrix[4] - pos[0]) / sx
+            oy = (view._matrix[5] - pos[1]) / sy
             factor = 0.9
             if event.get_scroll_direction()[1] == Gdk.ScrollDirection.UP:
-                factor = old_div(1.0, factor)
+                factor = 1.0 / factor
             view._matrix.translate(-ox, -oy)
             view._matrix.scale(factor, factor)
             view._matrix.translate(+ox, +oy)

--- a/gaphas/tree.py
+++ b/gaphas/tree.py
@@ -6,9 +6,6 @@ from builtins import map
 from builtins import object
 from builtins import range
 
-__version__ = "$Revision$"
-# $HeadURL$
-
 from operator import attrgetter
 
 

--- a/gaphas/util.py
+++ b/gaphas/util.py
@@ -4,11 +4,8 @@ canvas).
 """
 from __future__ import division
 
-
-__version__ = "$Revision$"
-# $HeadURL$
-
 from math import pi
+
 import cairo
 
 

--- a/gaphas/util.py
+++ b/gaphas/util.py
@@ -4,7 +4,6 @@ canvas).
 """
 from __future__ import division
 
-from past.utils import old_div
 
 __version__ = "$Revision$"
 # $HeadURL$
@@ -57,13 +56,13 @@ def text_align(cr, x, y, text, align_x=0, align_y=0, padding_x=0, padding_y=0):
 
     x_bear, y_bear, w, h, x_adv, y_adv = cr.text_extents(text)
     if align_x == 0:
-        x = 0.5 - (old_div(w, 2) + x_bear) + x
+        x = 0.5 - (w / 2 + x_bear) + x
     elif align_x < 0:
         x = -(w + x_bear) + x - padding_x
     else:
         x = x + padding_x
     if align_y == 0:
-        y = 0.5 - (old_div(h, 2) + y_bear) + y
+        y = 0.5 - (h / 2 + y_bear) + y
     elif align_y < 0:
         y = -(h + y_bear) + y - padding_y
     else:
@@ -131,7 +130,7 @@ def path_ellipse(cr, x, y, width, height, angle=0):
     cr.save()
     cr.translate(x, y)
     cr.rotate(angle)
-    cr.scale(old_div(width, 2.0), old_div(height, 2.0))
+    cr.scale(width / 2.0, height / 2.0)
     cr.move_to(1.0, 0.0)
     cr.arc(0.0, 0.0, 1.0, 0.0, 2.0 * pi)
     cr.restore()

--- a/gaphas/view.py
+++ b/gaphas/view.py
@@ -7,7 +7,6 @@ from __future__ import division
 from builtins import map
 from builtins import object
 
-import gi
 from cairo import Matrix
 from gi.repository import Gtk, GObject, Gdk
 
@@ -18,8 +17,6 @@ from .geometry import Rectangle, distance_point_point_fast
 from .painter import DefaultPainter, BoundingBoxPainter
 from .quadtree import Quadtree
 from .tool import DefaultTool
-
-gi.require_version("Gtk", "3.0")
 
 # Handy debug flag for drawing bounding boxes around the items.
 DEBUG_DRAW_BOUNDING_BOX = False

--- a/gaphas/view.py
+++ b/gaphas/view.py
@@ -6,7 +6,6 @@ from __future__ import division
 
 from builtins import map
 from builtins import object
-from past.utils import old_div
 
 __version__ = "$Revision$"
 # $HeadURL$
@@ -657,7 +656,7 @@ class GtkView(Gtk.DrawingArea, Gtk.Scrollable, View):
                 value=v.x,
                 lower=u.x,
                 upper=u.x1,
-                step_increment=old_div(aw, 10),
+                step_increment=aw // 10,
                 page_increment=aw,
                 page_size=aw,
             )
@@ -665,7 +664,7 @@ class GtkView(Gtk.DrawingArea, Gtk.Scrollable, View):
             self._hadjustment.set_value(v.x)
             self._hadjustment.set_lower(u.x)
             self._hadjustment.set_upper(u.x1)
-            self._hadjustment.set_step_increment(old_div(aw, 10))
+            self._hadjustment.set_step_increment(aw // 10)
             self._hadjustment.set_page_increment(aw)
             self._hadjustment.set_page_size(aw)
 
@@ -674,7 +673,7 @@ class GtkView(Gtk.DrawingArea, Gtk.Scrollable, View):
                 value=v.y,
                 lower=u.y,
                 upper=u.y1,
-                step_increment=old_div(ah, 10),
+                step_increment=ah // 10,
                 page_increment=ah,
                 page_size=ah,
             )
@@ -682,7 +681,7 @@ class GtkView(Gtk.DrawingArea, Gtk.Scrollable, View):
             self._vadjustment.set_value(v.y)
             self._vadjustment.set_lower(u.y)
             self._vadjustment.set_upper(u.y1)
-            self._vadjustment.set_step_increment(old_div(ah, 10))
+            self._vadjustment.set_step_increment(ah // 10)
             self._vadjustment.set_page_increment(ah)
             self._vadjustment.set_page_size(ah)
 

--- a/gaphas/view.py
+++ b/gaphas/view.py
@@ -7,21 +7,19 @@ from __future__ import division
 from builtins import map
 from builtins import object
 
-__version__ = "$Revision$"
-# $HeadURL$
-
 import gi
-
-gi.require_version("Gtk", "3.0")
-from gi.repository import Gtk, GObject, Gdk
 from cairo import Matrix
+from gi.repository import Gtk, GObject, Gdk
+
 from .canvas import Context
-from .geometry import Rectangle, distance_point_point_fast
-from .quadtree import Quadtree
-from .tool import DefaultTool
-from .painter import DefaultPainter, BoundingBoxPainter
 from .decorators import AsyncIO
 from .decorators import nonrecursive
+from .geometry import Rectangle, distance_point_point_fast
+from .painter import DefaultPainter, BoundingBoxPainter
+from .quadtree import Quadtree
+from .tool import DefaultTool
+
+gi.require_version("Gtk", "3.0")
 
 # Handy debug flag for drawing bounding boxes around the items.
 DEBUG_DRAW_BOUNDING_BOX = False


### PR DESCRIPTION
- This PR replaces use of the old_div futurize past util, with use of float and int division from Python3.
- It removes use of individual module __version__ information. We shouldn't need per module versions, pip should manage the version number for the entire package.
- It removes use of gi.require_version, this is only needed for the app that makes use of gaphas, and further cleaned up the imports.