### PR TITLE
Fix NameError: name 'get_scroll_direction' is not defined when scrolling

### DIFF
--- a/gaphas/tool.py
+++ b/gaphas/tool.py
@@ -522,7 +522,7 @@ class PanTool(Tool):
         if not event.get_state()[1] & PAN_MASK == PAN_VALUE:
             return False
         view = self.view
-        direction = get_scroll_direction()[1]
+        direction = event.get_scroll_direction()[1]
         if direction == Gdk.ScrollDirection.LEFT:
             view._matrix.translate(self.speed / view._matrix[0], 0)
         elif direction == Gdk.ScrollDirection.RIGHT:


### PR DESCRIPTION
A NameError was introduced during the migration to PyGObject so that the
Gtk.Event get_scroll_direction method wasn't being called on a
Gtk.Event. The NameError was raised every time the user scrolls with the
mouse.

Signed-off-by: Dan Yeaw <dan@yeaw.me>