### PR TITLE
Handle property deprecation

### DIFF
--- a/gaphas/connector.py
+++ b/gaphas/connector.py
@@ -3,6 +3,8 @@ Basic connectors such as Ports and Handles.
 """
 
 from builtins import object
+import functools
+import warnings
 
 from gaphas.constraint import LineConstraint, PositionConstraint
 from gaphas.geometry import distance_line_point, distance_point_point
@@ -10,8 +12,20 @@ from gaphas.solver import solvable, NORMAL
 from gaphas.state import observed, reversible_property
 
 
-def deprecated(e):
-    return e
+def deprecated(message, since):
+    def _deprecated(func):
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs):
+            warnings.warn(
+                "{}: {}".format(func.__name__, message),
+                category=DeprecationWarning,
+                stacklevel=2,
+            )
+            return func(*args, **kwargs)
+
+        return wrapper
+
+    return _deprecated
 
 
 class Position(object):
@@ -119,27 +133,31 @@ class Handle(object):
 
     pos = property(lambda s: s._pos, _set_pos)
 
+    @deprecated("Use Handle.pos", "1.1.0")
     def _set_x(self, x):
         """
         Shortcut for ``handle.pos.x = x``
         """
         self._pos.x = x
 
+    @deprecated("Use Handle.pos.x", "1.1.0")
     def _get_x(self):
         return self._pos.x
 
-    x = property(deprecated(_get_x), deprecated(_set_x))
+    x = property(_get_x, _set_x)
 
+    @deprecated("Use Handle.pos", "1.1.0")
     def _set_y(self, y):
         """
         Shortcut for ``handle.pos.y = y``
         """
         self._pos.y = y
 
+    @deprecated("Use Handle.pos.y", "1.1.0")
     def _get_y(self):
         return self._pos.y
 
-    y = property(deprecated(_get_y), deprecated(_set_y))
+    y = property(_get_y, _set_y)
 
     @observed
     def _set_connectable(self, connectable):

--- a/gaphas/painter.py
+++ b/gaphas/painter.py
@@ -90,8 +90,6 @@ class DrawContext(Context):
     focused.
     """
 
-    deprecated = False
-
     def __init__(self, **kwargs):
         super(DrawContext, self).__init__(**kwargs)
 

--- a/tests/test_canvas.py
+++ b/tests/test_canvas.py
@@ -157,8 +157,8 @@ def test_line_projection():
     line = Line()
     line.matrix.translate(15, 50)
     h1, h2 = line.handles()
-    h1.x, h1.y = 0, 0
-    h2.x, h2.y = 20, 20
+    h1.pos = (0, 0)
+    h2.pos = (20, 20)
 
     box = Box()
     box.matrix.translate(10, 10)
@@ -170,7 +170,7 @@ def test_line_projection():
     canvas.add(box)
 
     # move line's second handle on box side
-    h2.x, h2.y = 5, -20
+    h2.pos = (5, -20)
 
 
 def test_remove_connected_item():

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -26,5 +26,5 @@ def test_set_xy():
 
 def test_handle_x_y():
     h = Handle()
-    assert 0.0 == h.x
-    assert 0.0 == h.y
+    assert 0.0 == h.pos.x
+    assert 0.0 == h.pos.y


### PR DESCRIPTION
`Handle.x` and `Handle.y` were already somewhat marked as deprecated. We have `Handle.pos`, which contains the position of the hanndle. This should be the way to obtain the Handle's coordinates.

I added a bit of code that would actually print the deprecation warning and fixed the tests to not use those properties anymore.