### PR TITLE
Fix MethodType Given Wrong Number of Parameters

### DIFF
--- a/examples/demo.py
+++ b/examples/demo.py
@@ -493,5 +493,3 @@ if __name__ == "__main__":
         stats.print_stats(20)
     else:
         main()
-
-# vim: sw=4:et:

--- a/examples/demo_profile.py
+++ b/examples/demo_profile.py
@@ -22,5 +22,3 @@ if __name__ == "__main__":
         stats.strip_dirs()
         stats.sort_stats("time", "calls")
         stats.print_stats(20)
-
-# vim: sw=4:et:

--- a/gaphas/__init__.py
+++ b/gaphas/__init__.py
@@ -42,9 +42,7 @@ __version__ = "$Revision$"
 # $HeadURL$
 
 
-from .canvas import Canvas
-from .connector import Handle
-from .item import Item, Line, Element
-from .view import View, GtkView
-
-# vi:sw=4:et:ai
+from gaphas.canvas import Canvas
+from gaphas.connector import Handle
+from gaphas.item import Item, Line, Element
+from gaphas.view import View, GtkView

--- a/gaphas/aspect.py
+++ b/gaphas/aspect.py
@@ -340,9 +340,9 @@ class ItemConnectionSink(object):
 ConnectionSink = singledispatch(ItemConnectionSink)
 
 
-##
-## Painter aspects
-##
+#
+# Painter aspects
+#
 
 
 class ItemPaintFocused(object):
@@ -360,6 +360,3 @@ class ItemPaintFocused(object):
 
 
 PaintFocused = singledispatch(ItemPaintFocused)
-
-
-# vim:sw=4:et:ai

--- a/gaphas/canvas.py
+++ b/gaphas/canvas.py
@@ -1031,6 +1031,3 @@ __test__ = {
     "Canvas.remove": Canvas.remove,
     "Canvas.request_update": Canvas.request_update,
 }
-
-
-# vim:sw=4:et:ai

--- a/gaphas/canvas.py
+++ b/gaphas/canvas.py
@@ -41,7 +41,7 @@ from gaphas import solver
 from gaphas import table
 from gaphas import tree
 from gaphas.decorators import nonrecursive, AsyncIO
-from .state import observed, reversible_method, reversible_pair
+from gaphas.state import observed, reversible_method, reversible_pair
 
 #
 # Information about two connected items

--- a/gaphas/connector.py
+++ b/gaphas/connector.py
@@ -283,6 +283,3 @@ class PointPort(Port):
         point = canvas.project(item, handle.pos)
         c = PositionConstraint(origin, point)
         return c  # PositionConstraint(origin, point)
-
-
-# vim: sw=4:et:ai

--- a/gaphas/constraint.py
+++ b/gaphas/constraint.py
@@ -606,6 +606,3 @@ class LineAlignConstraint(Constraint):
 
         _update(px, x)
         _update(py, y)
-
-
-# vim:sw=4:et:ai

--- a/gaphas/decorators.py
+++ b/gaphas/decorators.py
@@ -213,6 +213,3 @@ class recursive(object):
                     func._recursion_level -= 1
 
         return wrapper
-
-
-# vim:sw=4:et:ai

--- a/gaphas/examples.py
+++ b/gaphas/examples.py
@@ -214,6 +214,3 @@ class Circle(Item):
         cr = context.cairo
         path_ellipse(cr, 0, 0, 2 * self.radius, 2 * self.radius)
         cr.stroke()
-
-
-# vim: sw=4:et:ai

--- a/gaphas/examples.py
+++ b/gaphas/examples.py
@@ -8,7 +8,7 @@ from __future__ import division
 from gaphas.connector import Handle, PointPort, LinePort, Position
 from gaphas.item import Element, Item, NW, NE, SW, SE
 from gaphas.solver import WEAK
-from .util import text_align, text_multiline, path_ellipse
+from gaphas.util import text_align, text_multiline, path_ellipse
 
 
 class Box(Element):

--- a/gaphas/freehand.py
+++ b/gaphas/freehand.py
@@ -15,7 +15,7 @@ from __future__ import absolute_import
 from builtins import object
 from math import sqrt
 from random import Random
-from .painter import Context
+from gaphas.painter import Context
 
 
 class FreeHandCairoContext(object):

--- a/gaphas/freehand.py
+++ b/gaphas/freehand.py
@@ -176,6 +176,3 @@ class FreeHandPainter(object):
             area=context.area,
         )
         self.subpainter.paint(subcontext)
-
-
-# vi:sw=4:et:ai

--- a/gaphas/geometry.py
+++ b/gaphas/geometry.py
@@ -618,6 +618,3 @@ def rectangle_clip(recta, rectb):
     if w < 0 or h < 0:
         return None
     return (x, y, w, h)
-
-
-# vim:sw=4:et:ai

--- a/gaphas/guide.py
+++ b/gaphas/guide.py
@@ -335,6 +335,3 @@ class GuidePainter(ItemPaintFocused):
                 cr.stroke()
         finally:
             cr.restore()
-
-
-# vim:sw=4:et:ai

--- a/gaphas/item.py
+++ b/gaphas/item.py
@@ -12,22 +12,27 @@ from math import atan2
 from weakref import WeakKeyDictionary
 
 try:
-    # python 3.0 (better be prepared)
+    # Python 3.0 (better be prepared)
     from weakref import WeakSet
 except ImportError:
-    from .weakset import WeakSet
+    from gaphas.weakset import WeakSet
 
-from .matrix import Matrix
-from .geometry import distance_line_point, distance_rectangle_point
-from .connector import Handle, LinePort
-from .solver import solvable, WEAK, VERY_STRONG, REQUIRED
-from .constraint import (
+from gaphas.matrix import Matrix
+from gaphas.geometry import distance_line_point, distance_rectangle_point
+from gaphas.connector import Handle, LinePort
+from gaphas.solver import solvable, WEAK, VERY_STRONG, REQUIRED
+from gaphas.constraint import (
     EqualsConstraint,
     LessThanConstraint,
     LineConstraint,
     LineAlignConstraint,
 )
-from .state import observed, reversible_method, reversible_pair, reversible_property
+from gaphas.state import (
+    observed,
+    reversible_method,
+    reversible_pair,
+    reversible_property,
+)
 
 
 class Item(object):

--- a/gaphas/item.py
+++ b/gaphas/item.py
@@ -734,16 +734,5 @@ class Line(Item):
         draw_line_end(self._handles[-1].pos, self._tail_angle, self.draw_tail)
         cr.stroke()
 
-        ### debug code to draw line ports
-        ### cr.set_line_width(1)
-        ### cr.set_source_rgb(1.0, 0.0, 0.0)
-        ### for p in self.ports():
-        ###     cr.move_to(*p.start)
-        ###     cr.line_to(*p.end)
-        ### cr.stroke()
-
 
 __test__ = {"Line._set_orthogonal": Line._set_orthogonal}
-
-
-# vim: sw=4:et:ai

--- a/gaphas/matrix.py
+++ b/gaphas/matrix.py
@@ -100,6 +100,3 @@ class Matrix(object):
 
     def __repr__(self):
         return "Matrix(%g, %g, %g, %g, %g, %g)" % tuple(self._matrix)
-
-
-# vim:sw=4:et

--- a/gaphas/matrix.py
+++ b/gaphas/matrix.py
@@ -16,7 +16,7 @@ __version__ = "$Revision$"
 # $HeadURL$
 
 import cairo
-from .state import observed, reversible_method
+from gaphas.state import observed, reversible_method
 
 
 class Matrix(object):

--- a/gaphas/painter.py
+++ b/gaphas/painter.py
@@ -389,6 +389,3 @@ def DefaultPainter(view=None):
         .append(FocusedItemPainter())
         .append(ToolPainter())
     )
-
-
-# vim: sw=4:et:ai

--- a/gaphas/painter.py
+++ b/gaphas/painter.py
@@ -10,16 +10,13 @@ from __future__ import division
 
 from builtins import object
 
-__version__ = "$Revision$"
-# $HeadURL$
+from cairo import ANTIALIAS_NONE, LINE_JOIN_ROUND
 
-from cairo import Matrix, ANTIALIAS_NONE, LINE_JOIN_ROUND
-
+from gaphas.aspect import PaintFocused
 from gaphas.canvas import Context
 from gaphas.geometry import Rectangle
-from gaphas.item import Line
-from gaphas.aspect import PaintFocused
 
+__version__ = "$Revision$"
 
 DEBUG_DRAW_BOUNDING_BOX = False
 

--- a/gaphas/picklers.py
+++ b/gaphas/picklers.py
@@ -41,6 +41,3 @@ def reduce_cairo_matrix(m):
 
 
 copyreg.pickle(cairo.Matrix, reduce_cairo_matrix, construct_cairo_matrix)
-
-
-# vim:sw=4:et:ai

--- a/gaphas/picklers.py
+++ b/gaphas/picklers.py
@@ -2,16 +2,16 @@
 Some extra picklers needed to gracefully dump and load a canvas.
 """
 
+import copyreg
+import types
+
+import cairo
 from future import standard_library
 
 standard_library.install_aliases()
-import copyreg
 
 
 # Allow instancemethod to be pickled:
-import types
-
-
 def construct_instancemethod(funcname, self, clazz):
     func = getattr(clazz, funcname)
     return types.MethodType(func, self)
@@ -28,10 +28,6 @@ copyreg.pickle(types.MethodType, reduce_instancemethod, construct_instancemethod
 
 
 # Allow cairo.Matrix to be pickled:
-
-import cairo
-
-
 def construct_cairo_matrix(*args):
     return cairo.Matrix(*args)
 

--- a/gaphas/picklers.py
+++ b/gaphas/picklers.py
@@ -10,23 +10,6 @@ from future import standard_library
 
 standard_library.install_aliases()
 
-
-# Allow instancemethod to be pickled:
-def construct_instancemethod(funcname, self, clazz):
-    func = getattr(clazz, funcname)
-    return types.MethodType(func, self)
-
-
-def reduce_instancemethod(im):
-    return (
-        construct_instancemethod,
-        (im.__func__.__name__, im.__self__, im.__self__.__class__),
-    )
-
-
-copyreg.pickle(types.MethodType, reduce_instancemethod, construct_instancemethod)
-
-
 # Allow cairo.Matrix to be pickled:
 def construct_cairo_matrix(*args):
     return cairo.Matrix(*args)

--- a/gaphas/picklers.py
+++ b/gaphas/picklers.py
@@ -14,7 +14,7 @@ import types
 
 def construct_instancemethod(funcname, self, clazz):
     func = getattr(clazz, funcname)
-    return types.MethodType(func, self, clazz)
+    return types.MethodType(func, self)
 
 
 def reduce_instancemethod(im):

--- a/gaphas/quadtree.py
+++ b/gaphas/quadtree.py
@@ -381,6 +381,3 @@ class QuadtreeBucket(object):
             print(indent, item, bounds)
         for bucket in self._buckets:
             bucket.dump(indent)
-
-
-# vim:sw=4:et:ai

--- a/gaphas/quadtree.py
+++ b/gaphas/quadtree.py
@@ -26,7 +26,7 @@ from builtins import map
 from builtins import object
 from builtins import zip
 
-from .geometry import rectangle_contains, rectangle_intersects, rectangle_clip
+from gaphas.geometry import rectangle_contains, rectangle_intersects, rectangle_clip
 
 
 class Quadtree(object):

--- a/gaphas/segment.py
+++ b/gaphas/segment.py
@@ -268,6 +268,3 @@ class LineSegmentPainter(ItemPaintFocused):
                 cr.set_line_width(1)
                 cr.stroke()
                 cr.restore()
-
-
-# vim:sw=4:et:ai

--- a/gaphas/solver.py
+++ b/gaphas/solver.py
@@ -39,7 +39,7 @@ from __future__ import division
 
 from builtins import object
 
-from .state import observed, reversible_pair, reversible_property
+from gaphas.state import observed, reversible_pair, reversible_property
 
 # epsilon for float comparison
 # is simple abs(x - y) > EPSILON enough for canvas needs?

--- a/gaphas/solver.py
+++ b/gaphas/solver.py
@@ -686,6 +686,3 @@ __test__ = {
     "Solver.add_constraint": Solver.add_constraint,
     "Solver.remove_constraint": Solver.remove_constraint,
 }
-
-
-# vim:sw=4:et:ai

--- a/gaphas/state.py
+++ b/gaphas/state.py
@@ -295,6 +295,3 @@ def getfunction(func):
         else:  # Legacy Python
             return func.__func__
     return func
-
-
-# vim:sw=4:et:ai

--- a/gaphas/table.py
+++ b/gaphas/table.py
@@ -178,6 +178,3 @@ class Table(object):
             except TypeError as ex:
                 pass
         return r
-
-
-# vi:sw=4:et:ai

--- a/gaphas/tool.py
+++ b/gaphas/tool.py
@@ -801,6 +801,3 @@ def DefaultTool(view=None):
         .append(TextEditTool())
         .append(RubberbandTool())
     )
-
-
-# vim: sw=4:et:ai

--- a/gaphas/tree.py
+++ b/gaphas/tree.py
@@ -347,6 +347,3 @@ class Tree(object):
         # reorganize children in nodes list
         for c in self._children[node]:
             self._reparent_nodes(c, node)
-
-
-# vi: sw=4:et:ai

--- a/gaphas/util.py
+++ b/gaphas/util.py
@@ -130,6 +130,3 @@ def path_ellipse(cr, x, y, width, height, angle=0):
     cr.move_to(1.0, 0.0)
     cr.arc(0.0, 0.0, 1.0, 0.0, 2.0 * pi)
     cr.restore()
-
-
-# vim:sw=4:et

--- a/gaphas/weakset.py
+++ b/gaphas/weakset.py
@@ -202,6 +202,3 @@ class WeakSet(object):
 
     def isdisjoint(self, other):
         return len(self.intersection(other)) == 0
-
-
-# vim:sw=4:et:ai


### PR DESCRIPTION
This PR fixes an error I saw when running the demo, caused by the wrong number of parameters given to `types.MethodType`. It also contains some other formatting cleanup.