### PR TITLE
Only use configure-event

### DIFF
--- a/gaphas/decorators.py
+++ b/gaphas/decorators.py
@@ -114,11 +114,10 @@ class AsyncIO(object):
 
     def __call__(self, func):
         async_id = "_async_id_%s" % func.__name__
-        source = self.source
 
         def wrapper(*args, **kwargs):
             global getattr, setattr, delattr
-            # execute directly if we're not in the main loop.
+            # execute directly if we're not in the main loop
             if GLib.main_depth() == 0:
                 return func(*args, **kwargs)
             elif not self.single:
@@ -128,7 +127,7 @@ class AsyncIO(object):
                         print("async:", func, args, kwargs)
                     func(*args, **kwargs)
 
-                source(async_wrapper).attach()
+                self.source(async_wrapper).attach()
             else:
                 # Idle handlers should be registered per instance
                 holder = args[0]
@@ -146,7 +145,7 @@ class AsyncIO(object):
                             delattr(holder, async_id)
                         return False
 
-                    setattr(holder, async_id, source(async_wrapper).attach())
+                    setattr(holder, async_id, self.source(async_wrapper).attach())
 
         return wrapper
 

--- a/gaphas/view.py
+++ b/gaphas/view.py
@@ -729,6 +729,7 @@ class GtkView(Gtk.DrawingArea, Gtk.Scrollable, View):
         """
         if not self.get_window():
             return
+        print("update")
 
         dirty_items = self._dirty_items
         dirty_matrix_items = self._dirty_matrix_items
@@ -781,6 +782,7 @@ class GtkView(Gtk.DrawingArea, Gtk.Scrollable, View):
     @AsyncIO(single=True)
     def update_back_buffer(self):
         if self.canvas and self._back_buffer:
+            print("update_back_buffer")
             allocation = self.get_allocation()
             cr = cairo.Context(self._back_buffer)
 
@@ -841,6 +843,7 @@ class GtkView(Gtk.DrawingArea, Gtk.Scrollable, View):
         Gtk.DrawingArea.do_unrealize(self)
 
     def do_configure_event(self, event):
+        print("do_configure_event")
         allocation = self.get_allocation()
         self.update_adjustments(allocation)
         self._qtree.resize((0, 0, allocation.width, allocation.height))

--- a/gaphas/view.py
+++ b/gaphas/view.py
@@ -791,7 +791,9 @@ class GtkView(Gtk.DrawingArea, Gtk.Scrollable, View):
             cr.paint()
             cr.restore()
 
-            items = self.get_items_in_rectangle((0, 0, allocation.width, allocation.height))
+            items = self.get_items_in_rectangle(
+                (0, 0, allocation.width, allocation.height)
+            )
 
             self.painter.paint(Context(cairo=cr, items=items, area=None))
 
@@ -817,7 +819,7 @@ class GtkView(Gtk.DrawingArea, Gtk.Scrollable, View):
                 cr.set_line_width(1.0)
                 draw_qtree_bucket(self._qtree._bucket)
 
-            super(GtkView, self).queue_draw_area(0, 0, allocation.width, allocation.height)
+            self.get_window().invalidate_rect(None, True)
 
     def do_realize(self):
         Gtk.DrawingArea.do_realize(self)

--- a/gaphas/view.py
+++ b/gaphas/view.py
@@ -730,7 +730,6 @@ class GtkView(Gtk.DrawingArea, Gtk.Scrollable, View):
         """
         if not self.get_window():
             return
-        print("update")
 
         dirty_items = self._dirty_items
         dirty_matrix_items = self._dirty_matrix_items
@@ -790,7 +789,6 @@ class GtkView(Gtk.DrawingArea, Gtk.Scrollable, View):
                 )
                 self._back_buffer_needs_resizing = False
 
-            print("update_back_buffer2")
             allocation = self.get_allocation()
             cr = cairo.Context(self._back_buffer)
 
@@ -853,7 +851,6 @@ class GtkView(Gtk.DrawingArea, Gtk.Scrollable, View):
         Gtk.DrawingArea.do_unrealize(self)
 
     def do_configure_event(self, event):
-        print("do_configure_event")
         allocation = self.get_allocation()
         self.update_adjustments(allocation)
         self._qtree.resize((0, 0, allocation.width, allocation.height))
@@ -871,8 +868,6 @@ class GtkView(Gtk.DrawingArea, Gtk.Scrollable, View):
         """
         if not self._canvas:
             return
-
-        print("do_draw")
 
         if not self._back_buffer:
             return

--- a/gaphas/view.py
+++ b/gaphas/view.py
@@ -680,19 +680,19 @@ class GtkView(Gtk.DrawingArea, Gtk.Scrollable, View):
         the item as update areas. Of course with a pythonic flavor:
         update any number of items at once.
         """
-        self.update()
+        self.update_back_buffer()
 
     def queue_draw_area(self, x, y, w, h):
         """
         Queue an update for portion of the view port.
         """
-        self.update()
+        self.update_back_buffer()
 
     def queue_draw_refresh(self):
         """
         Redraw the entire view.
         """
-        self.update()
+        self.update_back_buffer()
 
     def request_update(self, items, matrix_only_items=(), removed_items=()):
         """
@@ -781,6 +781,7 @@ class GtkView(Gtk.DrawingArea, Gtk.Scrollable, View):
     @AsyncIO(single=True)
     def update_back_buffer(self):
         if self.canvas and self._back_buffer:
+            allocation = self.get_allocation()
             cr = cairo.Context(self._back_buffer)
 
             cr.save()
@@ -788,9 +789,7 @@ class GtkView(Gtk.DrawingArea, Gtk.Scrollable, View):
             cr.paint()
             cr.restore()
 
-            width = self.get_allocated_width()
-            height = self.get_allocated_height()
-            items = self.get_items_in_rectangle((0, 0, width, height))
+            items = self.get_items_in_rectangle((0, 0, allocation.width, allocation.height))
 
             self.painter.paint(Context(cairo=cr, items=items, area=None))
 
@@ -816,8 +815,7 @@ class GtkView(Gtk.DrawingArea, Gtk.Scrollable, View):
                 cr.set_line_width(1.0)
                 draw_qtree_bucket(self._qtree._bucket)
 
-            a = self.get_allocation()
-            super(GtkView, self).queue_draw_area(0, 0, a.width, a.height)
+            super(GtkView, self).queue_draw_area(0, 0, allocation.width, allocation.height)
 
     def do_realize(self):
         Gtk.DrawingArea.do_realize(self)
@@ -850,7 +848,7 @@ class GtkView(Gtk.DrawingArea, Gtk.Scrollable, View):
             self._back_buffer = self.get_window().create_similar_surface(
                 cairo.Content.COLOR_ALPHA, allocation.width, allocation.height
             )
-            self.update()
+            self.update_back_buffer()
         else:
             self._back_buffer = None
 

--- a/gaphas/view.py
+++ b/gaphas/view.py
@@ -7,7 +7,7 @@ from __future__ import division
 from builtins import map
 from builtins import object
 
-from gi.repository import Gtk, GObject, Gdk
+from gi.repository import GLib, GObject, Gdk, Gtk
 import cairo
 
 from gaphas.canvas import Context
@@ -779,10 +779,10 @@ class GtkView(Gtk.DrawingArea, Gtk.Scrollable, View):
         finally:
             cr.restore()
 
-    @AsyncIO(single=True)
+    @AsyncIO(single=True, priority=GLib.PRIORITY_HIGH_IDLE)
     def update_back_buffer(self):
         if self.canvas and self._back_buffer:
-            print("update_back_buffer")
+            print("update_back_buffer2")
             allocation = self.get_allocation()
             cr = cairo.Context(self._back_buffer)
 
@@ -819,7 +819,7 @@ class GtkView(Gtk.DrawingArea, Gtk.Scrollable, View):
                 cr.set_line_width(1.0)
                 draw_qtree_bucket(self._qtree._bucket)
 
-            self.get_window().invalidate_rect(None, True)
+            self.get_window().invalidate_rect(allocation, True)
 
     def do_realize(self):
         Gtk.DrawingArea.do_realize(self)
@@ -865,6 +865,8 @@ class GtkView(Gtk.DrawingArea, Gtk.Scrollable, View):
         """
         if not self._canvas:
             return
+
+        print("do_draw")
 
         if not self._back_buffer:
             return


### PR DESCRIPTION
Do no longer set widget dimensions via size-allocate.

May be a fix for #63.