### PR TITLE
When reconnecting an item, also update the port

### DIFF
--- a/gaphas/canvas.py
+++ b/gaphas/canvas.py
@@ -376,7 +376,7 @@ class Canvas:
             disconnect_item(*cinfo)
 
     @observed
-    def reconnect_item(self, item, handle, constraint=None):
+    def reconnect_item(self, item, handle, port=None, constraint=None):
         """
         Update an existing connection. This is used to provide a new
         constraint to the connection. ``item`` and ``handle`` are
@@ -432,7 +432,12 @@ class Canvas:
         self._connections.delete(item=cinfo.item, handle=cinfo.handle)
 
         self._connections.insert(
-            item, handle, cinfo.connected, cinfo.port, constraint, cinfo.callback
+            item,
+            handle,
+            cinfo.connected,
+            port or cinfo.port,
+            constraint,
+            cinfo.callback,
         )
         if constraint:
             self._solver.add_constraint(constraint)
@@ -441,9 +446,10 @@ class Canvas:
         reconnect_item,
         reverse=reconnect_item,
         bind={
+            "port": lambda self, item, handle: self.get_connection(handle).port,
             "constraint": lambda self, item, handle: self.get_connection(
                 handle
-            ).constraint
+            ).constraint,
         },
     )
 

--- a/gaphas/segment.py
+++ b/gaphas/segment.py
@@ -166,7 +166,7 @@ class LineSegment:
             constraint = port.constraint(canvas, item, handle, connected)
 
             cinfo = canvas.get_connection(handle)
-            canvas.reconnect_item(item, handle, constraint=constraint)
+            canvas.reconnect_item(item, handle, port, constraint=constraint)
 
 
 @HandleFinder.register(Line)


### PR DESCRIPTION
When an item is reconnected, the port was not updated.

The connection information should present the actual state of the connection, including the right port.