### PR TITLE
Revert API Changes to Draw Method

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ The view context passed to the Items draw() method has the following properties:
 - focused - True if the item has the focus
 - hovered - True if the mouse pointer if over the item. Only the top-most item is marked as hovered.
 - dropzone - The item is marked as the drop zone. When this happens then an item is dragged over the item, and if it is     dropped, it will become a child of this item.
+- draw_all - True if everything drawable on the item should be drawn, for example, when calculating the bounding boxes of   an item.
 
 The View automatically calculates the bounding box for the item, based on the items drawn in the draw (context) function (this is only done when really necessary, e.g., after an update of the item). The bounding box is in viewport coordinates.
 
@@ -401,6 +402,7 @@ DrawContext(
     focused=(item is view.focused_item),
     hovered=(item is view.hovered_item),
     dropzone=(item is view.dropzone_item),
+    draw_all=self.draw_all,
 )
 ```
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -209,6 +209,7 @@ Special context for drawing the item. It contains a cairo context and properties
         focused=(item is view.focused_item),
         hovered=(item is view.hovered_item),
         dropzone=(item is view.dropzone_item),
+        draw_all=self.draw_all,
     )
 
 Class: ``gaphas.painter.ItemPainter``

--- a/gaphas/item.py
+++ b/gaphas/item.py
@@ -187,6 +187,8 @@ class Item:
         - view: the view that is to be rendered to
         - selected, focused, hovered, dropzone: view state of items
           (True/False)
+        - draw_all: a request to draw everything, for bounding box
+          calculations
         """
         pass
 

--- a/gaphas/painter.py
+++ b/gaphas/painter.py
@@ -86,6 +86,9 @@ class DrawContext(Context):
 
 
 class ItemPainter(Painter):
+
+    draw_all = False
+
     def draw_item(self, item, cairo):
         view = self.view
         cairo.save()
@@ -102,6 +105,7 @@ class ItemPainter(Painter):
                     focused=(item is view.focused_item),
                     hovered=(item is view.hovered_item),
                     dropzone=(item is view.dropzone_item),
+                    draw_all=self.draw_all,
                 )
             )
 
@@ -240,6 +244,8 @@ class BoundingBoxPainter(Painter):
     This specific case of an ItemPainter is used to calculate the
     bounding boxes (in canvas coordinates) for the items.
     """
+
+    draw_all = True
 
     def __init__(self, item_painter=None, view=None):
         super().__init__(view)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.masonry.api"
 
 [tool.poetry]
 name = "gaphas"
-version = "2.1.1"
+version = "2.1.2"
 description="Gaphas is a GTK+ based diagramming widget"
 authors = [
     "Arjan J. Molenaar <gaphor@gmail.com>",


### PR DESCRIPTION
Fixes #77 by reverting changes that removed the draw_all parameter from the draw method. This PR also bumps the version to prepare for a new bug fix release.

I have tested this with version 1.2.0 of Gaphor, and it resolves the issue. I also used it with the latest master version of Gaphor and it is compatible there as well.