### PR TITLE
Remove cache variables

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,29 +1,29 @@
 repos:
-- repo: https://github.com/ambv/black
-  rev: 19.10b0
-  hooks:
-  - id: black
-    language_version: python3
-- repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v0.770
-  hooks:
-  - id: mypy
-- repo: https://gitlab.com/pycqa/flake8
-  rev: 3.8.3
-  hooks:
-  - id: flake8
-- repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v3.2.0
-  hooks:
-  - id: check-toml
-  - id: check-yaml
-- repo: https://github.com/pre-commit/mirrors-isort
-  rev: v5.4.2
-  hooks:
-  - id: isort
-    additional_dependencies: [toml]
-- repo: https://github.com/myint/docformatter
-  rev: v1.3.1
-  hooks:
-    - id: docformatter
-      args: [--in-place]
+  - repo: https://github.com/ambv/black
+    rev: 19.10b0
+    hooks:
+      - id: black
+        language_version: python3
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v0.782
+    hooks:
+      - id: mypy
+  - repo: https://gitlab.com/pycqa/flake8
+    rev: 3.8.3
+    hooks:
+      - id: flake8
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v3.2.0
+    hooks:
+      - id: check-toml
+      - id: check-yaml
+  - repo: https://github.com/pre-commit/mirrors-isort
+    rev: v5.4.2
+    hooks:
+      - id: isort
+        additional_dependencies: [toml]
+  - repo: https://github.com/myint/docformatter
+    rev: v1.3.1
+    hooks:
+      - id: docformatter
+        args: [--in-place]

--- a/gaphas/canvas.py
+++ b/gaphas/canvas.py
@@ -96,7 +96,6 @@ class Canvas:
         self._connections = table.Table(Connection, list(range(4)))
         self._dirty_items = set()
         self._dirty_matrix_items = set()
-        self._dirty_index = False
 
         self._registered_views = set()
 
@@ -117,7 +116,6 @@ class Canvas:
         """
         assert item not in self._tree.nodes, f"Adding already added node {item}"
         self._tree.add(item, parent, index)
-        self._dirty_index = True
 
         self.update_matrix(item, parent)
 
@@ -165,8 +163,6 @@ class Canvas:
     def reparent(self, item, parent, index=None):
         """Set new parent for an item."""
         self._tree.reparent(item, parent, index)
-
-        self._dirty_index = True
 
     reversible_method(
         reparent,
@@ -619,10 +615,6 @@ class Canvas:
         """Perform an update of the items that requested an update."""
         sort = self.sort
 
-        if self._dirty_index:
-            self.update_index()
-            self._dirty_index = False
-
         def dirty_items_with_ancestors():
             for item in self._dirty_items:
                 yield item
@@ -767,13 +759,6 @@ class Canvas:
         """
         dirty_matrix_items = {item for item in items if item.normalize()}
         return self.update_matrices(dirty_matrix_items)
-
-    def update_index(self):
-        """Provide each item in the canvas with an index attribute.
-
-        This makes for fast searching of items.
-        """
-        self._tree.index_nodes("_canvas_index")
 
     def register_view(self, view):
         """Register a view on this canvas.

--- a/gaphas/item.py
+++ b/gaphas/item.py
@@ -1,7 +1,7 @@
 """Basic items."""
 from math import atan2
-from typing import TYPE_CHECKING, Dict, Optional, Set
-from weakref import WeakKeyDictionary, WeakSet
+from typing import Optional, Set
+from weakref import WeakSet
 
 from gaphas.connector import Handle, LinePort
 from gaphas.constraint import (
@@ -20,9 +20,6 @@ from gaphas.state import (
     reversible_pair,
     reversible_property,
 )
-
-if TYPE_CHECKING:
-    from gaphas.view import View
 
 
 class Item:
@@ -54,8 +51,6 @@ class Item:
         self._ports = []
 
         # used by gaphas.view.GtkView to hold item 2 view matrices (view=key)
-        self._matrix_i2v: Dict[View, Matrix] = WeakKeyDictionary()  # type: ignore[assignment]
-        self._matrix_v2i: Dict[View, Matrix] = WeakKeyDictionary()  # type: ignore[assignment]
         self._canvas_projections: Set[Projection] = WeakSet()  # type: ignore[assignment]
 
     @observed

--- a/gaphas/item.py
+++ b/gaphas/item.py
@@ -40,8 +40,6 @@ class Item:
     - _canvas:      canvas, which owns an item
     - _handles:     list of handles owned by an item
     - _ports:       list of ports, connectable areas of an item
-    - _matrix_i2c:  item to canvas coordinates matrix
-    - _matrix_c2i:  canvas to item coordinates matrix
     - _matrix_i2v:  item to view coordinates matrices
     - _matrix_v2i:  view to item coordinates matrices
     - _sort_key:  used to sort items
@@ -54,10 +52,6 @@ class Item:
         self._handles = []
         self._constraints = []
         self._ports = []
-
-        # used by gaphas.canvas.Canvas to hold conversion matrices
-        self._matrix_i2c = None
-        self._matrix_c2i = None
 
         # used by gaphas.view.GtkView to hold item 2 view matrices (view=key)
         self._matrix_i2v: Dict[View, Matrix] = WeakKeyDictionary()  # type: ignore[assignment]

--- a/gaphas/tree.py
+++ b/gaphas/tree.py
@@ -166,6 +166,10 @@ class Tree(Generic[T]):
         lnodes = len(nodes)
         list(map(setattr, nodes, [index_key] * lnodes, list(range(lnodes))))
 
+    def order(self, items):
+        items_set = set(items)
+        return list(n for n in self._nodes if n in items_set)
+
     def _add_to_nodes(self, node, parent, index=None):
         """Helper method to place nodes on the right location in the nodes list
         Called only from add() and reparent()"""

--- a/gaphas/tree.py
+++ b/gaphas/tree.py
@@ -142,30 +142,6 @@ class Tree(Generic[T]):
             yield parent
             parent = self.get_parent(parent)
 
-    def index_nodes(self, index_key):
-        """Provide each item in the tree with an index attribute. This makes
-        for fast sorting of items.
-
-        >>> class A(object):
-        ...     def __init__(self, n):
-        ...         self.n = n
-        ...     def __repr__(self):
-        ...         return self.n
-        >>> t = Tree()
-        >>> a = A('a')
-        >>> t.add(a)
-        >>> t.add(A('b'))
-        >>> t.add(A('c'), parent=a)
-        >>> t.nodes
-        [a, c, b]
-        >>> t.index_nodes('my_key')
-        >>> t.nodes[0].my_key, t.nodes[1].my_key, t.nodes[2].my_key
-        (0, 1, 2)
-        """
-        nodes = self.nodes
-        lnodes = len(nodes)
-        list(map(setattr, nodes, [index_key] * lnodes, list(range(lnodes))))
-
     def order(self, items):
         items_set = set(items)
         return list(n for n in self._nodes if n in items_set)

--- a/gaphas/view.py
+++ b/gaphas/view.py
@@ -188,7 +188,7 @@ class View:
         """
         assert self._canvas
         items = self._qtree.find_intersect((pos[0], pos[1], 1, 1))
-        for item in self._canvas.sort(items, reverse=True):
+        for item in reversed(self._canvas.sort(items)):
             if not selected and item in self.selected_items:
                 continue  # skip selected items
 
@@ -232,8 +232,10 @@ class View:
 
         # Last try all items, checking the bounding box first
         x, y = pos
-        items = self.get_items_in_rectangle(
-            (x - distance, y - distance, distance * 2, distance * 2), reverse=True
+        items = reversed(
+            self.get_items_in_rectangle(
+                (x - distance, y - distance, distance * 2, distance * 2)
+            )
         )
 
         for item in items:
@@ -271,7 +273,7 @@ class View:
         item = None
 
         rect = (vx - distance, vy - distance, distance * 2, distance * 2)
-        items = self.get_items_in_rectangle(rect, reverse=True)
+        items = reversed(self.get_items_in_rectangle(rect))
         for i in items:
             if i in exclude:
                 continue
@@ -296,7 +298,7 @@ class View:
 
         return item, port, glue_pos
 
-    def get_items_in_rectangle(self, rect, intersect=True, reverse=False):
+    def get_items_in_rectangle(self, rect, intersect=True):
         """Return the items in the rectangle 'rect'.
 
         Items are automatically sorted in canvas' processing order.
@@ -306,7 +308,7 @@ class View:
             items = self._qtree.find_intersect(rect)
         else:
             items = self._qtree.find_inside(rect)
-        return self._canvas.sort(items, reverse=reverse)
+        return self._canvas.sort(items)
 
     def select_in_rectangle(self, rect):
         """Select all items who have their bounding box within the rectangle.

--- a/tests/test_canvas.py
+++ b/tests/test_canvas.py
@@ -19,8 +19,8 @@ def test_update_matrices():
 
     c.update_matrices([i])
 
-    assert i._matrix_i2c == cairo.Matrix(1, 0, 0, 1, 5, 0)
-    assert ii._matrix_i2c == cairo.Matrix(1, 0, 0, 1, 5, 8)
+    assert c.get_matrix_i2c(i) == cairo.Matrix(1, 0, 0, 1, 5, 0)
+    assert c.get_matrix_i2c(ii) == cairo.Matrix(1, 0, 0, 1, 5, 8)
 
 
 def test_reparent():

--- a/tests/test_view.py
+++ b/tests/test_view.py
@@ -6,7 +6,6 @@ from gi.repository import Gtk
 
 from gaphas.canvas import Canvas
 from gaphas.examples import Box
-from gaphas.item import Line
 from gaphas.view import GtkView, View
 
 
@@ -31,45 +30,6 @@ class ViewFixture:
 @pytest.fixture()
 def view_fixture():
     return ViewFixture()
-
-
-def test_bounding_box_calculations(view_fixture):
-    """A view created before and after the canvas is populated should contain
-    the same data."""
-    view_fixture.view.realize()
-    view_fixture.box.matrix = (1.0, 0.0, 0.0, 1, 10, 10)
-
-    line = Line()
-    line.fuzziness = 1
-    line.handles()[1].pos = (30, 30)
-    line.matrix.translate(30, 60)
-    view_fixture.canvas.add(line)
-
-    window2 = Gtk.Window.new(Gtk.WindowType.TOPLEVEL)
-    view2 = GtkView(canvas=view_fixture.canvas)
-    window2.add(view2)
-    window2.show_all()
-
-    # Process pending (expose) events, which cause the canvas to be drawn.
-    while Gtk.events_pending():
-        Gtk.main_iteration()
-
-    try:
-        assert view2.get_item_bounding_box(view_fixture.box)
-        assert view_fixture.view.get_item_bounding_box(view_fixture.box)
-        assert view_fixture.view.get_item_bounding_box(
-            view_fixture.box
-        ) == view2.get_item_bounding_box(
-            view_fixture.box
-        ), f"{view_fixture.view.get_item_bounding_box(view_fixture.box)} != {view2.get_item_bounding_box(view_fixture.box)}"
-        assert view_fixture.view.get_item_bounding_box(
-            line
-        ) == view2.get_item_bounding_box(
-            line
-        ), f"{view_fixture.view.get_item_bounding_box(line)} != {view2.get_item_bounding_box(line)}"
-    finally:
-        view_fixture.window.destroy()
-        window2.destroy()
 
 
 def test_get_item_at_point(view_fixture):

--- a/tests/test_view.py
+++ b/tests/test_view.py
@@ -70,8 +70,6 @@ def test_get_handle_at_point_at_pi_div_2(view_fixture):
     box.matrix.translate(20, 20)
     box.matrix.rotate(math.pi / 2)
     view_fixture.canvas.add(box)
-    box.matrix.translate(20, 20)
-    box.matrix.rotate(math.pi / 2)
 
     i, h = view_fixture.view.get_handle_at_point((20, 20))
     assert i is box
@@ -101,57 +99,30 @@ def test_view_registration(view_fixture):
     box = Box()
     canvas.add(box)
 
-    # By default no complex updating/calculations are done:
-    assert view not in box._matrix_i2v
-    assert view not in box._matrix_v2i
-
     # GTK view does register for updates though
 
     view = GtkView(canvas)
     assert len(canvas._registered_views) == 1
 
-    # No entry, since GtkView is not realized and has no window
-    assert view not in box._matrix_i2v
-    assert view not in box._matrix_v2i
-
     window = Gtk.Window.new(Gtk.WindowType.TOPLEVEL)
     window.add(view)
     window.show_all()
 
-    # Now everything is realized and updated
-    assert view in box._matrix_i2v
-    assert view in box._matrix_v2i
-
     view.canvas = None
     assert len(canvas._registered_views) == 0
-
-    assert view not in box._matrix_i2v
-    assert view not in box._matrix_v2i
 
     view.canvas = canvas
     assert len(canvas._registered_views) == 1
 
-    assert view in box._matrix_i2v
-    assert view in box._matrix_v2i
-
 
 def test_view_registration_2(view_fixture):
     """Test view registration and destroy when view is destroyed."""
-    assert hasattr(view_fixture.box, "_matrix_i2v")
-    assert hasattr(view_fixture.box, "_matrix_v2i")
-
-    assert view_fixture.box._matrix_i2v[view_fixture.view]
-    assert view_fixture.box._matrix_v2i[view_fixture.view]
-
     assert len(view_fixture.canvas._registered_views) == 1
     assert view_fixture.view in view_fixture.canvas._registered_views
 
     view_fixture.window.destroy()
 
     assert len(view_fixture.canvas._registered_views) == 0
-
-    assert view_fixture.view not in view_fixture.box._matrix_i2v
-    assert view_fixture.view not in view_fixture.box._matrix_v2i
 
 
 @pytest.fixture()


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [X] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes

### What is the current behavior?

Item is used as a cache for matrix mappings (item to canvas/view and vise versa)

### What is the new behavior?

The values are calculated on the fly. Normally the trees are not that deep, so there's no benefit caching these items.

Also item indexing has been removed.

There's one last cache (`_canvas_projections`), which will be addressed in a future PR.

### Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
