### PR TITLE
Matrix as method

### DIFF
--- a/docs/api/variable.rst
+++ b/docs/api/variable.rst
@@ -7,7 +7,7 @@ it easy to work with.
 Next to that there's Position, which is a coordinate ``(x, y)`` defined by two variables.
 
 To support connections between variables, a ``MatrixProjection`` class is available. It translates
-a position to a common coordinate space, baed on ``Item.matrix_i2c``. Normally, it's only ``Ports`` that
+a position to a common coordinate space, based on ``Item.matrix_i2c()``. Normally, it's only ``Ports`` that
 deal with item-to-common translation of positions.
 
 .. autoclass:: gaphas.solver.Variable

--- a/examples/demo.py
+++ b/examples/demo.py
@@ -369,36 +369,36 @@ def create_canvas(c=None):
     b = MyBox(c.connections)
     b.min_width = 20
     b.min_height = 30
-    b.matrix.translate(20, 20)
+    b.matrix().translate(20, 20)
     b.width = b.height = 40
     c.add(b)
 
     bb = Box(c.connections)
-    bb.matrix.translate(10, 10)
+    bb.matrix().translate(10, 10)
     c.add(bb, parent=b)
 
     bb = Box(c.connections)
-    bb.matrix.rotate(math.pi / 1.567)
+    bb.matrix().rotate(math.pi / 1.567)
     c.add(bb, parent=b)
 
     circle = Circle()
     h1, h2 = circle.handles()
     circle.radius = 20
-    circle.matrix.translate(50, 160)
+    circle.matrix().translate(50, 160)
     c.add(circle)
 
     pb = Box(c.connections, 60, 60)
     pb.min_width = 40
     pb.min_height = 50
-    pb.matrix.translate(100, 20)
+    pb.matrix().translate(100, 20)
     c.add(pb)
 
     ut = UnderlineText()
-    ut.matrix.translate(100, 130)
+    ut.matrix().translate(100, 130)
     c.add(ut)
 
     t = MyText("Single line")
-    t.matrix.translate(100, 170)
+    t.matrix().translate(100, 170)
     c.add(t)
 
     line = MyLine(c.connections)
@@ -406,7 +406,7 @@ def create_canvas(c=None):
     line.handles()[1].pos = (30, 30)
     segment = Segment(line, c)
     segment.split_segment(0, 3)
-    line.matrix.translate(30, 80)
+    line.matrix().translate(30, 80)
     line.orthogonal = True
 
     return c

--- a/examples/simple-box.py
+++ b/examples/simple-box.py
@@ -25,19 +25,19 @@ def create_canvas(canvas, title):
 
     # Draw first gaphas box
     b1 = Box(60, 60)
-    b1.matrix.translate(10, 10)
+    b1.matrix().translate(10, 10)
     canvas.add(b1)
 
     # Draw second gaphas box
     b2 = Box(60, 60)
     b2.min_width = 40
     b2.min_height = 50
-    b2.matrix.translate(170, 170)
+    b2.matrix().translate(170, 170)
     canvas.add(b2)
 
     # Draw gaphas line
     line = Line(canvas.connections)
-    line.matrix.translate(100, 60)
+    line.matrix().translate(100, 60)
     canvas.add(line)
     line.handles()[1].pos = (30, 30)
 

--- a/gaphas/aspect/move.py
+++ b/gaphas/aspect/move.py
@@ -36,7 +36,7 @@ class ItemMove:
         dx, dy = v2i.transform_distance(dx, dy)
         self.last_x, self.last_y = x, y
 
-        item.matrix.translate(dx, dy)
+        item.matrix().translate(dx, dy)
         view.model.request_update(item, update=False)
 
     def stop_move(self, pos: Pos) -> None:

--- a/gaphas/canvas.py
+++ b/gaphas/canvas.py
@@ -229,7 +229,7 @@ class Canvas:
             present yet. Note that out-of-date matrices are not
             recalculated.
         """
-        m = item.matrix
+        m = item.matrix()
 
         parent = self._tree.get_parent(item)
         if parent is not None:
@@ -277,9 +277,9 @@ class Canvas:
         try:
             # keep it here, since we need up to date matrices for the solver
             for d in dirty_items:
-                d.matrix_i2c.set(*self.get_matrix_i2c(d))
+                d.matrix_i2c().set(*self.get_matrix_i2c(d))
             for d in dirty_matrix_items:
-                d.matrix_i2c.set(*self.get_matrix_i2c(d))
+                d.matrix_i2c().set(*self.get_matrix_i2c(d))
 
             # solve all constraints
             self._connections.solve()

--- a/gaphas/connector.py
+++ b/gaphas/connector.py
@@ -146,9 +146,9 @@ class LinePort(Port):
     def constraint(self, item: Item, handle: Handle, glue_item: Item) -> Constraint:
         """Create connection line constraint between item's handle and the
         port."""
-        start = MatrixProjection(self.start, glue_item.matrix_i2c)
-        end = MatrixProjection(self.end, glue_item.matrix_i2c)
-        point = MatrixProjection(handle.pos, item.matrix_i2c)
+        start = MatrixProjection(self.start, glue_item.matrix_i2c())
+        end = MatrixProjection(self.end, glue_item.matrix_i2c())
+        point = MatrixProjection(handle.pos, item.matrix_i2c())
         line = LineConstraint((start.pos, end.pos), point.pos)
         return MultiConstraint(start, end, point, line)
 
@@ -177,7 +177,7 @@ class PointPort(Port):
     ) -> MultiConstraint:
         """Return connection position constraint between item's handle and the
         port."""
-        origin = MatrixProjection(self.point, glue_item.matrix_i2c)
-        point = MatrixProjection(handle.pos, item.matrix_i2c)
+        origin = MatrixProjection(self.point, glue_item.matrix_i2c())
+        point = MatrixProjection(handle.pos, item.matrix_i2c())
         c = PositionConstraint(origin.pos, point.pos)
         return MultiConstraint(origin, point, c)

--- a/gaphas/item.py
+++ b/gaphas/item.py
@@ -39,11 +39,9 @@ class Item(Protocol):
     All items that are rendered on a view.
     """
 
-    @property
     def matrix(self) -> Matrix:
         """The "local", item-to-parent matrix."""
 
-    @property
     def matrix_i2c(self) -> Matrix:
         """Matrix from item to toplevel."""
 
@@ -72,8 +70,8 @@ class Item(Protocol):
 
 
 def matrix_i2i(from_item: Item, to_item: Item) -> Matrix:
-    i2c = from_item.matrix_i2c
-    c2i = to_item.matrix_i2c.inverse()
+    i2c = from_item.matrix_i2c()
+    c2i = to_item.matrix_i2c().inverse()
     return i2c.multiply(c2i)
 
 
@@ -83,11 +81,9 @@ class Matrices:
         self._matrix = Matrix()
         self._matrix_i2c = Matrix()
 
-    @property
     def matrix(self) -> Matrix:
         return self._matrix
 
-    @property
     def matrix_i2c(self) -> Matrix:
         return self._matrix_i2c
 

--- a/gaphas/painter/boundingboxpainter.py
+++ b/gaphas/painter/boundingboxpainter.py
@@ -110,7 +110,7 @@ class BoundingBoxPainter:
         bounds = bbctx.get_bounds()
 
         # Update bounding box with handles.
-        i2c = item.matrix_i2c.transform_point
+        i2c = item.matrix_i2c().transform_point
         for h in item.handles():
             cx, cy = cairo.user_to_device(*i2c(*h.pos))
             bounds += (cx - 5, cy - 5, 9, 9)

--- a/gaphas/painter/handlepainter.py
+++ b/gaphas/painter/handlepainter.py
@@ -50,7 +50,7 @@ class HandlePainter:
             else:
                 r, g, b = 0, 0, 1
 
-            vx, vy = cairo.user_to_device(*item.matrix_i2c.transform_point(*h.pos))
+            vx, vy = cairo.user_to_device(*item.matrix_i2c().transform_point(*h.pos))
 
             cairo.save()
             cairo.identity_matrix()

--- a/gaphas/painter/itempainter.py
+++ b/gaphas/painter/itempainter.py
@@ -21,7 +21,7 @@ class ItemPainter:
     def paint_item(self, item: Item, cairo: CairoContext) -> None:
         cairo.save()
         try:
-            cairo.transform(item.matrix_i2c.to_cairo())
+            cairo.transform(item.matrix_i2c().to_cairo())
 
             selection = self.selection
             item.draw(

--- a/gaphas/segment.py
+++ b/gaphas/segment.py
@@ -40,7 +40,7 @@ class LineSegment:
     def split(self, pos):
         item = self.item
         handles = item.handles()
-        x, y = item.matrix_i2c.inverse().transform_point(*pos)
+        x, y = item.matrix_i2c().inverse().transform_point(*pos)
         for h1, h2 in zip(handles, handles[1:]):
             xp = (h1.pos.x + h2.pos.x) / 2
             yp = (h1.pos.y + h2.pos.y) / 2
@@ -232,7 +232,7 @@ def maybe_split_segment(view, item, pos):
         except TypeError:
             pass
         else:
-            cpos = view.matrix.inverse().transform_point(*pos)
+            cpos = view.matrix().inverse().transform_point(*pos)
             handle = segment.split(cpos)
     return handle
 
@@ -283,7 +283,9 @@ class LineSegmentPainter:
                 p1, p2 = h1.pos, h2.pos
                 cx = (p1.x + p2.x) / 2
                 cy = (p1.y + p2.y) / 2
-                vx, vy = cairo.user_to_device(*item.matrix_i2c.transform_point(cx, cy))
+                vx, vy = cairo.user_to_device(
+                    *item.matrix_i2c().transform_point(cx, cy)
+                )
                 cairo.save()
                 cairo.set_antialias(ANTIALIAS_NONE)
                 cairo.identity_matrix()

--- a/gaphas/tool/placement.py
+++ b/gaphas/tool/placement.py
@@ -33,7 +33,7 @@ def on_drag_begin(gesture, start_x, start_y, placement_state):
     view = gesture.get_widget()
     item = placement_state.factory()
     x, y = view.get_matrix_v2i(item).transform_point(start_x, start_y)
-    item.matrix.translate(x, y)
+    item.matrix().translate(x, y)
     view.selection.unselect_all()
     view.selection.focused_item = item
 

--- a/gaphas/tool/scroll.py
+++ b/gaphas/tool/scroll.py
@@ -14,6 +14,6 @@ def scroll_tool(view: GtkView, speed: int = 5) -> Gtk.EventControllerScroll:
 
 def on_scroll(controller, dx, dy, speed):
     view = controller.get_widget()
-    m = view.matrix
+    m = view.matrix()
     m.translate(-dx * speed, -dy * speed)
     view.request_update((), view.model.get_all_items())

--- a/gaphas/tool/zoom.py
+++ b/gaphas/tool/zoom.py
@@ -26,8 +26,8 @@ def zoom_tool(view: GtkView) -> Gtk.GestureZoom:
 def on_begin(gesture: Gtk.GestureZoom, sequence: None, zoom_data: ZoomData,) -> None:
     _, zoom_data.x0, zoom_data.y0 = gesture.get_point(sequence)
     view = gesture.get_widget()
-    zoom_data.sx = view.matrix[0]
-    zoom_data.sy = view.matrix[3]
+    zoom_data.sx = view.matrix()[0]
+    zoom_data.sy = view.matrix()[3]
 
 
 def on_scale_changed(
@@ -39,7 +39,7 @@ def on_scale_changed(
         scale = 20.0 / zoom_data.sx
 
     view = gesture.get_widget()
-    m = view.matrix
+    m = view.matrix()
     sx = m[0]
     sy = m[3]
     ox = (m[4] - zoom_data.x0) / sx

--- a/gaphas/view/gtkview.py
+++ b/gaphas/view/gtkview.py
@@ -130,14 +130,13 @@ class GtkView(Gtk.DrawingArea, Gtk.Scrollable):
     def do_set_property(self, prop: str, value: object) -> None:
         self._scrolling.set_property(prop, value)
 
-    @property
     def matrix(self) -> Matrix:
         """Model root to view transformation matrix."""
         return self._matrix
 
     def get_matrix_i2v(self, item: Item) -> Matrix:
         """Get Item to View matrix for ``item``."""
-        return item.matrix_i2c.multiply(self._matrix)
+        return item.matrix_i2c().multiply(self._matrix)
 
     def get_matrix_v2i(self, item: Item) -> Matrix:
         """Get View to Item matrix for ``item``."""
@@ -240,7 +239,7 @@ class GtkView(Gtk.DrawingArea, Gtk.Scrollable):
     def zoom(self, factor: float) -> None:
         """Zoom in/out by factor ``factor``."""
         assert self._model
-        self.matrix.scale(factor, factor)
+        self.matrix().scale(factor, factor)
         self.request_update((), self._model.get_all_items())
 
     def get_items_in_rectangle(
@@ -367,7 +366,7 @@ class GtkView(Gtk.DrawingArea, Gtk.Scrollable):
             else instant_cairo_context()
         )
 
-        cr.set_matrix(self.matrix.to_cairo())
+        cr.set_matrix(self._matrix.to_cairo())
         cr.save()
         cr.rectangle(0, 0, 0, 0)
         cr.clip()
@@ -413,7 +412,7 @@ class GtkView(Gtk.DrawingArea, Gtk.Scrollable):
                 (0, 0, allocation.width, allocation.height)
             )
 
-            cr.set_matrix(self.matrix.to_cairo())
+            cr.set_matrix(self.matrix().to_cairo())
             cr.save()
             self.painter.paint(list(items), cr)
             cr.restore()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "gaphas"
-version = "3.0.0-beta.2"
+version = "3.0.0-beta.3"
 description="Gaphas is a GTK+ based diagramming widget"
 authors = [
     "Arjan J. Molenaar <gaphor@gmail.com>",

--- a/tests/test_aspect.py
+++ b/tests/test_aspect.py
@@ -15,7 +15,7 @@ def test_selection_move(canvas, view, item):
     """Test the Selection role methods."""
     canvas.add(item)
     mover = Move(item, view)
-    assert (1, 0, 0, 1, 0, 0) == tuple(item.matrix)
+    assert (1, 0, 0, 1, 0, 0) == tuple(item.matrix())
     mover.start_move((0, 0))
     mover.move((12, 26))
-    assert (1, 0, 0, 1, 12, 26) == tuple(item.matrix)
+    assert (1, 0, 0, 1, 12, 26) == tuple(item.matrix())

--- a/tests/test_canvas.py
+++ b/tests/test_canvas.py
@@ -20,8 +20,8 @@ def test_update_matrices():
     c.add(i)
     c.add(ii, i)
 
-    i.matrix.translate(5.0, 0.0)
-    ii.matrix.translate(0.0, 8.0)
+    i.matrix().translate(5.0, 0.0)
+    ii.matrix().translate(0.0, 8.0)
 
     assert c.get_matrix_i2c(i) == Matrix(1, 0, 0, 1, 5, 0)
     assert c.get_matrix_i2c(ii) == Matrix(1, 0, 0, 1, 5, 8)

--- a/tests/test_guide.py
+++ b/tests/test_guide.py
@@ -84,29 +84,29 @@ def test_guide_item_in_motion(connections, canvas, view, window):
     canvas.add(e2)
     canvas.add(e3)
 
-    assert 0 == e1.matrix[4]
-    assert 0 == e1.matrix[5]
+    assert 0 == e1.matrix()[4]
+    assert 0 == e1.matrix()[5]
 
-    e2.matrix.translate(40, 40)
+    e2.matrix().translate(40, 40)
     canvas.request_update(e2)
-    assert 40 == e2.matrix[4]
-    assert 40 == e2.matrix[5]
+    assert 40 == e2.matrix()[4]
+    assert 40 == e2.matrix()[5]
 
     guider = GuidedItemMove(e3, view)
 
     guider.start_move((0, 0))
-    assert 0 == e3.matrix[4]
-    assert 0 == e3.matrix[5]
+    assert 0 == e3.matrix()[4]
+    assert 0 == e3.matrix()[5]
 
     # Moved back to guided lines:
     for d in range(3):
         guider.move((d, d))
-        assert 0 == e3.matrix[4]
-        assert 0 == e3.matrix[5]
+        assert 0 == e3.matrix()[4]
+        assert 0 == e3.matrix()[5]
 
     guider.move((20, 20))
-    assert 20 == e3.matrix[4]
-    assert 20 == e3.matrix[5]
+    assert 20 == e3.matrix()[4]
+    assert 20 == e3.matrix()[5]
 
 
 def test_guide_item_in_motion_2(connections, canvas, view):
@@ -117,27 +117,27 @@ def test_guide_item_in_motion_2(connections, canvas, view):
     canvas.add(e2)
     canvas.add(e3)
 
-    assert 0 == e1.matrix[4]
-    assert 0 == e1.matrix[5]
+    assert 0 == e1.matrix()[4]
+    assert 0 == e1.matrix()[5]
 
-    e2.matrix.translate(40, 40)
+    e2.matrix().translate(40, 40)
     canvas.request_update(e2)
-    assert 40 == e2.matrix[4]
-    assert 40 == e2.matrix[5]
+    assert 40 == e2.matrix()[4]
+    assert 40 == e2.matrix()[5]
 
     guider = GuidedItemMove(e3, view)
 
     guider.start_move((3, 3))
-    assert 0 == e3.matrix[4]
-    assert 0 == e3.matrix[5]
+    assert 0 == e3.matrix()[4]
+    assert 0 == e3.matrix()[5]
 
     # Moved back to guided lines:
     for y in range(4, 6):
         guider.move((3, y))
-        assert 0 == e3.matrix[4]
-        assert 0 == e3.matrix[5]
+        assert 0 == e3.matrix()[4]
+        assert 0 == e3.matrix()[5]
 
     # Take into account initial cursor offset of (3, 3)
     guider.move((20, 23))
-    assert 17 == e3.matrix[4]
-    assert 20 == e3.matrix[5]
+    assert 17 == e3.matrix()[4]
+    assert 20 == e3.matrix()[5]

--- a/tests/test_tool_item.py
+++ b/tests/test_tool_item.py
@@ -85,8 +85,8 @@ def test_get_handle_at_point(view, canvas, connections):
     box = Box(connections)
     box.min_width = 20
     box.min_height = 30
-    box.matrix.translate(20, 20)
-    box.matrix.rotate(math.pi / 1.5)
+    box.matrix().translate(20, 20)
+    box.matrix().rotate(math.pi / 1.5)
     canvas.add(box)
 
     i, h = handle_at_point(view, (20, 20))
@@ -98,8 +98,8 @@ def test_get_handle_at_point_at_pi_div_2(view, canvas, connections):
     box = Box(connections)
     box.min_width = 20
     box.min_height = 30
-    box.matrix.translate(20, 20)
-    box.matrix.rotate(math.pi / 2)
+    box.matrix().translate(20, 20)
+    box.matrix().rotate(math.pi / 2)
     canvas.add(box)
 
     i, h = handle_at_point(view, (20, 20))

--- a/tests/test_tool_scroll.py
+++ b/tests/test_tool_scroll.py
@@ -14,5 +14,5 @@ def test_offset_changes(view):
 
     on_scroll(tool, 10, 10, 1)
 
-    assert view.matrix[4] == -10
-    assert view.matrix[5] == -10
+    assert view.matrix()[4] == -10
+    assert view.matrix()[5] == -10

--- a/tests/test_tool_zoom.py
+++ b/tests/test_tool_zoom.py
@@ -44,8 +44,8 @@ def test_scaling(zoom_data, view):
 
     on_scale_changed(tool, 1.2, zoom_data)
 
-    assert view.matrix[0] == 1.2
-    assert view.matrix[3] == 1.2
+    assert view.matrix()[0] == 1.2
+    assert view.matrix()[3] == 1.2
 
 
 def test_multiple_scaling_events(zoom_data, view):
@@ -54,8 +54,8 @@ def test_multiple_scaling_events(zoom_data, view):
     on_scale_changed(tool, 1.1, zoom_data)
     on_scale_changed(tool, 1.2, zoom_data)
 
-    assert view.matrix[0] == 1.2
-    assert view.matrix[3] == 1.2
+    assert view.matrix()[0] == 1.2
+    assert view.matrix()[3] == 1.2
 
 
 def test_scaling_with_unequal_scaling_factor(zoom_data, view):
@@ -64,8 +64,8 @@ def test_scaling_with_unequal_scaling_factor(zoom_data, view):
 
     on_scale_changed(tool, 1.2, zoom_data)
 
-    assert view.matrix[0] == 2.4
-    assert view.matrix[3] == 1.2
+    assert view.matrix()[0] == 2.4
+    assert view.matrix()[3] == 1.2
 
 
 def test_zoom_should_center_around_mouse_cursor(zoom_data, view):
@@ -75,8 +75,8 @@ def test_zoom_should_center_around_mouse_cursor(zoom_data, view):
 
     on_scale_changed(tool, 1.2, zoom_data)
 
-    assert view.matrix[4] == -20.0
-    assert view.matrix[5] == -10.0
+    assert view.matrix()[4] == -20.0
+    assert view.matrix()[5] == -10.0
 
 
 def test_zoom_out_should_be_limited_to_20_percent(zoom_data, view):
@@ -84,8 +84,8 @@ def test_zoom_out_should_be_limited_to_20_percent(zoom_data, view):
 
     on_scale_changed(tool, 0.0, zoom_data)
 
-    assert view.matrix[0] == 0.2
-    assert view.matrix[3] == 0.2
+    assert view.matrix()[0] == 0.2
+    assert view.matrix()[3] == 0.2
 
 
 def test_zoom_in_should_be_limited_to_20_times(zoom_data, view):
@@ -93,5 +93,5 @@ def test_zoom_in_should_be_limited_to_20_times(zoom_data, view):
 
     on_scale_changed(tool, 100.0, zoom_data)
 
-    assert view.matrix[0] == 20
-    assert view.matrix[3] == 20
+    assert view.matrix()[0] == 20
+    assert view.matrix()[3] == 20


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [X] Refactoring (no functional changes, ~no~ api changes)
- [ ] Documentation content changes

### What is the current behavior?

The Item protocol feels a bit awkward. On the one hand there's `handles()` and `ports()`, which are normal methods. On the other hand there's `matrix` and `matrix_i2c`, which are implemented as properties.

### What is the new behavior?

I made `matrix` and `matrix_i2c` methods as well. Firstly, because they make type checking easier. Also, this takes away the "overhead" of calling a property.

The alternative is to make `handles` and `ports` properties, which is a tempting alternative.

I'm in doubt what would be the best way to go. The first option (methods) is simple, the second (properties) may result in more idiomatic python.

### Does this PR introduce a breaking change?
- [X] Yes
- [ ] No

@danyeaw What do you think?
