### PR TITLE
Remove JuggleError

### DIFF
--- a/gaphas/solver/__init__.py
+++ b/gaphas/solver/__init__.py
@@ -1,5 +1,5 @@
 from gaphas.solver.constraint import BaseConstraint, Constraint, MultiConstraint
-from gaphas.solver.solver import JuggleError, Solver
+from gaphas.solver.solver import Solver
 from gaphas.solver.variable import (
     NORMAL,
     REQUIRED,

--- a/gaphas/solver/solver.py
+++ b/gaphas/solver/solver.py
@@ -196,11 +196,3 @@ def find_containing_constraint(
         ):
             return find_containing_constraint(cs, constraints)
     return None
-
-
-class JuggleError(AssertionError):
-    """Variable juggling exception.
-
-    Raised when constraint's variables are marking each other dirty
-    forever.
-    """

--- a/gaphas/solver/solver.py
+++ b/gaphas/solver/solver.py
@@ -44,11 +44,12 @@ class Solver:
     A constraint should have accompanying variables.
     """
 
-    def __init__(self) -> None:
+    def __init__(self, resolve_limit: int = 16) -> None:
         # a dict of constraint -> name/variable mappings
         self._constraints: Set[Constraint] = set()
         self._marked_cons: List[Constraint] = []
         self._solving = False
+        self._resolve_limit = resolve_limit
         self._handlers: Set[Callable[[Constraint], None]] = set()
 
     def add_handler(self, handler: Callable[[Constraint], None]) -> None:
@@ -129,12 +130,8 @@ class Solver:
             if c in self._marked_cons:
                 self._marked_cons.remove(c)
             self._marked_cons.append(c)
-        else:
+        elif self._marked_cons.count(c) < self._resolve_limit:
             self._marked_cons.append(c)
-            if self._marked_cons.count(c) > 100:
-                raise JuggleError(
-                    f"Variable juggling detected, constraint {c} resolved {self._marked_cons.count(c)} times out of {len(self._marked_cons)}"
-                )
 
     def solve(self) -> None:
         """

--- a/tests/test_solver.py
+++ b/tests/test_solver.py
@@ -1,8 +1,7 @@
 """Test constraint solver."""
-import pytest
 
 from gaphas.constraint import EqualsConstraint, EquationConstraint, LessThanConstraint
-from gaphas.solver import REQUIRED, JuggleError, MultiConstraint, Solver, Variable
+from gaphas.solver import REQUIRED, MultiConstraint, Solver, Variable
 from gaphas.solver.constraint import Constraint, ContainsConstraints
 
 
@@ -79,7 +78,7 @@ def test_minimal_size_constraint():
     assert 10 == v3
 
 
-def test_juggle_error_is_raised_when_constraints_can_not_be_resolved():
+def test_constraints_can_not_be_resolved():
     solver = Solver()
     a = Variable()
     b = Variable()
@@ -90,8 +89,10 @@ def test_juggle_error_is_raised_when_constraints_can_not_be_resolved():
     solver.add_constraint(EqualsConstraint(a, c))
     solver.add_constraint(EqualsConstraint(b, d))
 
-    with pytest.raises(JuggleError):
-        solver.solve()
+    solver.solve()
+
+    assert a.value == 40.0
+    assert b.value == 30.0
 
 
 def test_notify_for_nested_constraint():


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes

### What is the current behavior?

When two constraints are in conflict, an exception is raised (`JuggleError`) and the solver stays in an undetermined state.

Issue Number: N/A

### What is the new behavior?

Instead of raising an exception, there's a cap on how many times a constraint may be resolved. This cap is configurable (16 by default).

### Does this PR introduce a breaking change?
- [X] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information

For normal cases this will not make a difference. It will save us some unexpected errors. Alternatively we should handle the exceptions ourselves (in Gaphor). There's not much a user can do, so we could just as well stop resolving.

This is a simpler solution that introducing a completely new solver (#342).