### PR TITLE
Integrate line segments

### DIFF
--- a/docs/segment.rst
+++ b/docs/segment.rst
@@ -7,12 +7,13 @@ The line segment functionality is an add-on, that will allow the user to add lin
    :align: center
 
 To use this behavior, import the ``gaphas.segment`` module and add ``LineSegmentPainter`` to the list of painters for the view.
-Add ``segment_tool`` to the view as a controller, in order to activate the split/merge segment behavior for ``Line`` instances.
+Splitting and merging of lines is supported by ``item_tool``, however
+to actually use it, the ``segment`` module needs to be imported.
 
     >>> from gaphas.view import GtkView
     >>> from gaphas.painter import PainterChain, ItemPainter, HandlePainter
     >>> from gaphas.tool import item_tool, scroll_tool, zoom_tool
-    >>> from gaphas.segment import LineSegmentPainter, segment_tool
+    >>> from gaphas.segment import LineSegmentPainter
     >>> view = GtkView()
     >>> view.painter = (
     ...     PainterChain()
@@ -20,7 +21,6 @@ Add ``segment_tool`` to the view as a controller, in order to activate the split
     ...     .append(HandlePainter(view))
     ...     .append(LineSegmentPainter(view.selection))
     ... )
-    >>> view.add_controller(segment_tool(view))
     >>> view.add_controller(item_tool(view))
     >>> view.add_controller(scroll_tool(view))
     >>> view.add_controller(zoom_tool(view))

--- a/examples/demo.py
+++ b/examples/demo.py
@@ -33,7 +33,7 @@ from gaphas.painter import (
     ItemPainter,
     PainterChain,
 )
-from gaphas.segment import LineSegmentPainter, Segment, segment_tool
+from gaphas.segment import LineSegmentPainter
 from gaphas.tool import (
     hover_tool,
     item_tool,
@@ -42,6 +42,7 @@ from gaphas.tool import (
     view_focus_tool,
     zoom_tool,
 )
+from gaphas.tool.itemtool import Segment
 from gaphas.tool.rubberband import RubberbandPainter, RubberbandState, rubberband_tool
 from gaphas.util import text_extents, text_underline
 from gaphas.view import GtkView
@@ -120,7 +121,6 @@ def rubberband_state(view):
 
 def apply_default_tool_set(view):
     view.remove_all_controllers()
-    view.add_controller(segment_tool(view))
     view.add_controller(item_tool(view))
     view.add_controller(*scroll_tools(view))
     view.add_controller(zoom_tool(view))

--- a/gaphas/segment.py
+++ b/gaphas/segment.py
@@ -160,6 +160,13 @@ class LineSegment:
             model.connections.reconnect_item(item, handle, port, constraint=constraint)
 
 
+def segment_tool(view):
+    print(
+        "WARNING: You're using segment_tool(). Remove all uses of segment_tool() from your code. It's handled by item_tool now."
+    )
+    return None
+
+
 class LineSegmentPainter:
     """This painter draws pseudo-handles on gaphas.item.Line objects. Each line
     can be split by dragging those points, which will result in a new handle.

--- a/gaphas/tool/itemtool.py
+++ b/gaphas/tool/itemtool.py
@@ -1,4 +1,5 @@
 import logging
+from functools import singledispatch
 from typing import Optional, Tuple, Union
 
 from gi.repository import Gdk, Gtk
@@ -6,7 +7,7 @@ from gi.repository import Gdk, Gtk
 from gaphas.aspect import HandleMove, Move, item_at_point
 from gaphas.canvas import ancestors
 from gaphas.connector import Handle
-from gaphas.geometry import distance_point_point_fast
+from gaphas.geometry import distance_line_point, distance_point_point_fast
 from gaphas.item import Item
 from gaphas.types import Pos
 from gaphas.view import GtkView
@@ -35,13 +36,14 @@ class DragState:
 
 def on_drag_begin(gesture, start_x, start_y, drag_state):
     view = gesture.get_widget()
+    pos = (start_x, start_y)
     selection = view.selection
     modifiers = (
         gesture.get_last_event(None).get_state()[1]
         if Gtk.get_major_version() == 3
         else gesture.get_current_event_state()
     )
-    item, handle = find_item_and_handle_at_point(view, (start_x, start_y))
+    item, handle = find_item_and_handle_at_point(view, pos)
 
     # Deselect all items unless CTRL or SHIFT is pressed
     # or the item is already selected.
@@ -63,6 +65,9 @@ def on_drag_begin(gesture, start_x, start_y, drag_state):
         selection.unselect_item(item)
         gesture.set_state(Gtk.EventSequenceState.DENIED)
         return
+
+    if not handle and item is view.selection.focused_item:
+        handle = maybe_split_segment(view, item, pos)
 
     selection.focused_item = item
     gesture.set_state(Gtk.EventSequenceState.CLAIMED)
@@ -113,6 +118,8 @@ def on_drag_end(gesture, offset_x, offset_y, drag_state):
     _, x, y = gesture.get_start_point()
     for moving in drag_state.moving:
         moving.stop_move((x + offset_x, y + offset_y))
+        if hasattr(moving, "item") and hasattr(moving, "handle"):
+            maybe_merge_segments(gesture.get_widget(), moving.item, moving.handle)
     drag_state.moving = set()
 
 
@@ -170,3 +177,60 @@ def handle_at_point(
         if h:
             return item, h
     return None, None
+
+
+@singledispatch
+class Segment:
+    def __init__(self, item, model):
+        raise TypeError
+
+    def split_segment(self, segment, count=2):
+        ...
+
+    def split(self, pos):
+        ...
+
+    def merge_segment(self, segment, count=2):
+        ...
+
+
+def maybe_split_segment(view, item, pos):
+    try:
+        segment = Segment(item, view.model)
+    except TypeError:
+        return None
+    else:
+        cpos = view.matrix.inverse().transform_point(*pos)
+        return segment.split(cpos)
+
+
+def maybe_merge_segments(view, item, handle):
+    handles = item.handles()
+
+    # don't merge using first or last handle
+    if handles[0] is handle or handles[-1] is handle:
+        return
+
+    # ensure at least three handles
+    handle_index = handles.index(handle)
+    segment = handle_index - 1
+
+    # cannot merge starting from last segment
+    if segment == len(item.ports()) - 1:
+        segment = -1
+    assert segment >= 0 and segment < len(item.ports()) - 1
+
+    before = handles[handle_index - 1]
+    after = handles[handle_index + 1]
+    d, p = distance_line_point(before.pos, after.pos, handle.pos)
+
+    if d > 4:
+        return
+
+    try:
+        Segment(item, view.model).merge_segment(segment)
+    except ValueError:
+        pass
+    else:
+        if handle:
+            view.model.request_update(item)


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes

### What is the current behavior?

We're using common GTK controllers to handle events. This does not work well
when certain controllers act on the same input events. In our case `item_tool`
and `segment_tool`. I thought this could be fixed by giving `segment_tool`
preference. Change it's propagation level to `TARGET`. This raised another issue:
for line splitting the segment tool was used, but for line merging `item_tool`
was used. Hence, line segments are never merged.

Apart from that, the update handlers for both segment_tool and item_tool were identical.

Issue Number: https://github.com/gaphor/gaphor/issues/1175

### What is the new behavior?

Lines are properly split and merged as before. The `gaphas.segment` module should still be loaded to activate this behavior. However, the split/merge behavior is now initiated from `item_tool`.

### Does this PR introduce a breaking change?
- [x] Yes
- [ ] No

* `segment_tool` is gone.

### Other information

@danyeaw: This PR fixes issue we have with the segment tool. I liked `segment_tool` to be a separate tool, but it looks like the `Gtk.Controller` makes it hard on us. For every phase in the event propagation all event handlers are ran, something I did not expect. Hence, `item_tool` and `segment_tool` can not really coexist. Moving the segment interface (singledispatch) into `item_tool`, but keeping the implementations in a separate module, still gives us the freedom to enable/disable segments, but avoids the conflicts with controllers we currently have.