### PR TITLE
Fix Ctrl-scroll zoom for GTK4

### DIFF
--- a/examples/demo.py
+++ b/examples/demo.py
@@ -19,7 +19,7 @@ import gi
 # fmt: off
 GTK4 = "-4" in sys.argv
 gi.require_version("Gtk", "4.0" if GTK4 else "3.0")  # noqa: isort:skip
-from gi.repository import GLib, Gtk  # noqa: isort:skip
+from gi.repository import Gtk  # noqa: isort:skip
 # fmt: on
 
 from examples.exampleitems import Box, Circle, Text
@@ -39,7 +39,7 @@ from gaphas.tool import (
     item_tool,
     placement_tool,
     view_focus_tool,
-    zoom_tool,
+    zoom_tools,
 )
 from gaphas.tool.itemtool import Segment
 from gaphas.tool.rubberband import RubberbandPainter, RubberbandState, rubberband_tool
@@ -121,7 +121,8 @@ def rubberband_state(view):
 def apply_default_tool_set(view):
     view.remove_all_controllers()
     view.add_controller(item_tool(view))
-    view.add_controller(zoom_tool(view))
+    for tool in zoom_tools(view):
+        view.add_controller(tool)
     view.add_controller(view_focus_tool(view))
 
     view.add_controller(rubberband_tool(view, rubberband_state(view)))
@@ -136,7 +137,8 @@ def apply_placement_tool_set(view, item_type, handle_index):
     view.remove_all_controllers()
     tool = placement_tool(view, factory(view, item_type), handle_index)
     tool.connect("drag-end", unset_placement_tool)
-    view.add_controller(zoom_tool(view))
+    for tool in zoom_tools(view):
+        view.add_controller(tool)
     view.add_controller(view_focus_tool(view))
     view.add_controller(tool)
 

--- a/gaphas/tool/__init__.py
+++ b/gaphas/tool/__init__.py
@@ -35,4 +35,4 @@ from gaphas.tool.placement import placement_tool
 from gaphas.tool.rubberband import rubberband_tool
 from gaphas.tool.scroll import scroll_tool, scroll_tools
 from gaphas.tool.viewfocus import view_focus_tool
-from gaphas.tool.zoom import zoom_tool
+from gaphas.tool.zoom import zoom_tool, zoom_tools


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes

### What is the current behavior?

Apps like Firefox and Inkscape use Ctrl+scroll wheel to zoom.

Issue Number: https://github.com/gaphor/gaphor/issues/1798

### What is the new behavior?

Scroll-zoom works on GTK4.
For GTK3 it's not possible, since scroll events can't be propagated.
