### PR TITLE
CI updates for egress and update runners

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -89,8 +89,8 @@ jobs:
           key: ${{ runner.os }}-${{ hashFiles('**/poetry.lock') }}
       - name: Install Ubuntu Dependencies
         run: |
-          sudo apt update -qq
-          sudo apt install -qq --no-install-recommends gir1.2-gtk-4.0 libgirepository1.0-dev
+          sudo apt-get update -qq
+          sudo apt-get install -qq --no-install-recommends gir1.2-gtk-4.0 libgirepository1.0-dev libcairo2-dev
       - name: Install Poetry
         run: |
           python${{ matrix.python-version }} -m pip install --constraint=.github/constraints.txt poetry

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   lint:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@91182cccc01eb5e619899d80e4e971d6181294a7 # v2.10.1
@@ -42,7 +42,7 @@ jobs:
 
   build:
     needs: lint
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     permissions:
       contents: write
     strategy:
@@ -123,7 +123,7 @@ jobs:
   publish-to-pypi:
     name: Publish to PyPI (release only)
     needs: build
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     permissions:
       id-token: write
     if: ${{ github.event_name == 'release' }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,7 @@ on:
     types: [created, published]
 
 env:
-  python-version: '3.12'
+  python-version: '3.13'
 
 permissions:
   contents: read
@@ -47,7 +47,7 @@ jobs:
       contents: write
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
     name: build python ${{ matrix.python-version }}
     outputs:
       targz: gaphas-${{ steps.meta.outputs.version }}.tar.gz

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,8 +22,10 @@ jobs:
           egress-policy: block
           allowed-endpoints: >
             files.pythonhosted.org:443
-            github.com:443
             pypi.org:443
+            github.com:443
+            *.githubusercontent.com:443
+            ghcr.io
 
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Set up Python
@@ -63,14 +65,16 @@ jobs:
             codeclimate.com:443
             d3iz1jjs17r6kg.cloudfront.net:443
             files.pythonhosted.org:443
+            pypi.org:443
             github.com:443
+            *.githubusercontent.com:443
+            ghcr.io
             gitlab.gnome.org:443
             keys.openpgp.org:443
             motd.ubuntu.com:443
             esm.ubuntu.com:443
             packages.microsoft.com:443
             ppa.launchpadcontent.net:443
-            pypi.org:443
 
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Set up Python ${{ matrix.python-version }}
@@ -135,6 +139,8 @@ jobs:
           egress-policy: block
           allowed-endpoints: >
             upload.pypi.org:443
+            *.githubusercontent.com:443
+            ghcr.io
 
       - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
         with:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -15,7 +15,7 @@ permissions:
 jobs:
   analyze:
     name: Analyze
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -24,7 +24,21 @@ jobs:
       - name: Harden Runner
         uses: step-security/harden-runner@91182cccc01eb5e619899d80e4e971d6181294a7 # v2.10.1
         with:
-          egress-policy: audit
+          egress-policy: block
+          allowed-endpoints: >
+            api.github.com:443
+            github.com:443
+            *.githubusercontent.com:443
+            ghcr.io
+            uploads.github.com:443
+            azure.archive.ubuntu.com:80
+            esm.ubuntu.com:443
+            motd.ubuntu.com:443
+            packages.microsoft.com:443
+            ppa.launchpadcontent.net:443
+            files.pythonhosted.org:443
+            pypi.org:443
+            gitlab.gnome.org:443
 
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   dependency-review:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@91182cccc01eb5e619899d80e4e971d6181294a7 # v2.10.1

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -19,7 +19,13 @@ jobs:
       - name: Harden Runner
         uses: step-security/harden-runner@91182cccc01eb5e619899d80e4e971d6181294a7 # v2.10.1
         with:
-          egress-policy: audit
+          egress-policy: block
+          allowed-endpoints: >
+            api.github.com:443
+            api.securityscorecards.dev:443
+            github.com:443
+            *.githubusercontent.com:443
+            ghcr.io
 
       - name: 'Checkout Repository'
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -10,7 +10,7 @@ jobs:
   pr-labeler:
     permissions:
       pull-requests: write  # for TimonVS/pr-labeler-action to add labels in PR
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     if: "!contains(github.event.head_commit.message, 'skip ci')"
     steps:
       - name: Harden Runner

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -16,7 +16,11 @@ jobs:
       - name: Harden Runner
         uses: step-security/harden-runner@91182cccc01eb5e619899d80e4e971d6181294a7 # v2.10.1
         with:
-          egress-policy: audit
+          egress-policy: block
+          allowed-endpoints: >
+            api.github.com:443
+            *.githubusercontent.com:443
+            ghcr.io
 
       - uses: TimonVS/pr-labeler-action@f9c084306ce8b3f488a8f3ee1ccedc6da131d1af # v5.0.0
         env:

--- a/.github/workflows/pre-commit-updater.yml
+++ b/.github/workflows/pre-commit-updater.yml
@@ -1,0 +1,60 @@
+name: Pre-commit updater
+on:
+  workflow_dispatch:
+  schedule:
+    # min hour dom month dow
+    - cron:  '0 5 * * 3'
+env:
+  python_version: '3.13'
+
+jobs:
+
+  updater:
+    name: Update
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@0080882f6c36860b6ba35c610c98ce87d4e2f26f # v2.10.2
+        with:
+          disable-sudo: true
+          egress-policy: block
+          allowed-endpoints: >
+            files.pythonhosted.org:443
+            pypi.org:443
+            github.com:443
+            api.github.com:443
+            *.githubusercontent.com:443
+            ghcr.io
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: main
+      - name: Set up Python
+        uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
+        with:
+          python-version: ${{ env.python_version }}
+          cache: pip
+      - name: Install pre-commit
+        run: python -m pip install pre-commit
+      - name: Update pre-commit hooks
+        run: pre-commit autoupdate --freeze
+      - name: Run pre-commit hooks
+        run: pre-commit run --all-files
+      - name: Create GitHub App Token
+        uses: actions/create-github-app-token@5d869da34e18e7287c1daad50e0b8ea0f506ce69 # v1.11.0
+        id: generate-token
+        with:
+          app-id: ${{ secrets.GAPHOR_UPDATER_APP_ID }}
+          private-key: ${{ secrets.GAPHOR_UPDATER_APP_PRIVATE_KEY }}
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@5e914681df9dc83aa4e4905692ca88beb2f9e91f # v7.0.5
+        with:
+          token: ${{ steps.generate-token.outputs.token }}
+          commit-message: Update pre-commit hooks
+          branch: pre-commit-update
+          delete-branch: true
+          title: 'Update pre-commit hooks'
+          body: |
+            This PR was automatically created to make the following update:
+            - Update pre-commit hooks
+          labels: |
+            skip-changelog

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -12,7 +12,7 @@ jobs:
     permissions:
       contents: write  # for release-drafter/release-drafter to create a github release
       pull-requests: write  # for release-drafter/release-drafter to add label to PR
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     if: "!contains(github.event.head_commit.message, 'skip ci')"
     steps:
       # Drafts your next Release notes as Pull Requests are merged into "main"

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -19,7 +19,11 @@ jobs:
       - name: Harden Runner
         uses: step-security/harden-runner@91182cccc01eb5e619899d80e4e971d6181294a7 # v2.10.1
         with:
-          egress-policy: audit
+          egress-policy: block
+          allowed-endpoints: >
+            api.github.com:443
+            *.githubusercontent.com:443
+            ghcr.io
 
       - uses: release-drafter/release-drafter@3f0f87098bd6b5c5b9a36d49c41d998ea58f9348 # v6.0.0
         env:

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -20,7 +20,7 @@ permissions: read-all
 jobs:
   analysis:
     name: Scorecard analysis
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       # Needed to upload the results to code-scanning dashboard.
       security-events: write

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -33,7 +33,24 @@ jobs:
       - name: Harden Runner
         uses: step-security/harden-runner@91182cccc01eb5e619899d80e4e971d6181294a7 # v2.10.1
         with:
-          egress-policy: audit
+          egress-policy: block
+          allowed-endpoints: >
+            api.deps.dev:443
+            api.github.com:443
+            github.com:443
+            *.githubusercontent.com:443
+            ghcr.io
+            api.osv.dev:443
+            api.scorecard.dev:443
+            api.securityscorecards.dev:443
+            auth.docker.io:443
+            cdn.fwupd.org:443
+            fulcio.sigstore.dev:443
+            index.docker.io:443
+            oss-fuzz-build-logs.storage.googleapis.com:443
+            rekor.sigstore.dev:443
+            tuf-repo-cdn.sigstore.dev:443
+            www.bestpractices.dev:443
 
       - name: "Checkout code"
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -3,7 +3,7 @@ formats: all
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.11"
+    python: "3.13"
   apt_packages:
   - libgirepository1.0-dev
   jobs:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,7 +1,7 @@
 version: 2
 formats: all
 build:
-  os: ubuntu-22.04
+  os: ubuntu-24.04
   tools:
     python: "3.13"
   apt_packages:


### PR DESCRIPTION
This PR updates to match the other Gaphor repositories:
1. Blocks egress except allowed endpoints
2. Updates runners to Ubuntu 24.04
3. Adds Python 3.13 to test matrix
4. Adds a pre-commit update workflow

### PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I have read and I am following the [Contributor guide](https://github.com/gaphor/gaphas/blob/main/CONTRIBUTING.md)
- [X] I have read and I understand the [Code of Conduct](https://github.com/gaphor/gaphas/blob/main/CODE_OF_CONDUCT.md)

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [X] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes

### What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

### What is the new behavior?

### Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
