### PR TITLE
Fix macOS drag

### DIFF
--- a/gaphas/tool/itemtool.py
+++ b/gaphas/tool/itemtool.py
@@ -34,6 +34,8 @@ class DragState:
     def reset(self):
         self.moving_items = set()
         self.moving_handle = None
+        self.start_x = 0
+        self.start_y = 0
 
     @property
     def moving(self):
@@ -76,6 +78,9 @@ def on_drag_begin(gesture, start_x, start_y, drag_state):
     selection.focused_item = item
     gesture.set_state(Gtk.EventSequenceState.CLAIMED)
 
+    drag_state.start_x = start_x
+    drag_state.start_y = start_y
+
     if handle:
         drag_state.moving_handle = HandleMove(item, handle, view)
     else:
@@ -105,10 +110,9 @@ def moving_items(view):
 
 
 def on_drag_update(gesture, offset_x, offset_y, drag_state):
-    _, sx, sy = gesture.get_start_point()
     view = gesture.get_widget()
-    x = sx + offset_x
-    y = sy + offset_y
+    x = drag_state.start_x + offset_x
+    y = drag_state.start_y + offset_y
 
     for moving in drag_state.moving:
         moving.move((x, y))
@@ -118,9 +122,8 @@ def on_drag_update(gesture, offset_x, offset_y, drag_state):
 
 
 def on_drag_end(gesture, offset_x, offset_y, drag_state):
-    _, x, y = gesture.get_start_point()
     for moving in drag_state.moving:
-        moving.stop_move((x + offset_x, y + offset_y))
+        moving.stop_move((drag_state.start_x + offset_x, drag_state.start_y + offset_y))
     if drag_state.moving_handle:
         moving = drag_state.moving_handle
         maybe_merge_segments(gesture.get_widget(), moving.item, moving.handle)

--- a/gaphas/tool/placement.py
+++ b/gaphas/tool/placement.py
@@ -26,6 +26,8 @@ class PlacementState:
         self.factory = factory
         self.handle_index = handle_index
         self.moving: MoveType | None = None
+        self.start_x = 0
+        self.start_y = 0
 
 
 def on_drag_begin(gesture, start_x, start_y, placement_state):
@@ -40,17 +42,21 @@ def on_drag_begin(gesture, start_x, start_y, placement_state):
 
     handle = item.handles()[placement_state.handle_index]
     if handle.movable:
+        placement_state.start_x = start_x
+        placement_state.start_y = start_y
         placement_state.moving = HandleMove(item, handle, view)
         placement_state.moving.start_move((start_x, start_y))
 
 
 def on_drag_update(gesture, offset_x, offset_y, placement_state):
     if placement_state.moving:
-        _, x, y = gesture.get_start_point()
-        placement_state.moving.move((x + offset_x, y + offset_y))
+        placement_state.moving.move(
+            (placement_state.start_x + offset_x, placement_state.start_y + offset_y)
+        )
 
 
 def on_drag_end(gesture, offset_x, offset_y, placement_state):
     if placement_state.moving:
-        _, x, y = gesture.get_start_point()
-        placement_state.moving.stop_move((x + offset_x, y + offset_y))
+        placement_state.moving.stop_move(
+            (placement_state.start_x + offset_x, placement_state.start_y + offset_y)
+        )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gaphas"
-version = "5.0.0"
+version = "5.0.1"
 description="Gaphas is a GTK diagramming widget"
 authors = [
     { name = "Arjan Molenaar", email = "gaphor@gmail.com" },


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes

### What is the current behavior?

In Gaphor sometimes, especially on macOS, the moved items jump back to their original place when. This may be because by the time the [`Gesture::end`](https://docs.gtk.org/gtk4/signal.Gesture.end.html) signal is triggered, the sequence is no longer valid.

The `Gtk.Gesture::end` handler (which emits `Gtk.GestureDrag::drag-end`) doesn't check if the sequence is handled by the gesture, while `Gtk.GestureDrag.get_start_point()` does. Hence, we do get an offset, but we cannot obtain the start position from the sequence anymore.

Issue Number: Fixes https://github.com/gaphor/gaphor/issues/3753

### What is the new behavior?

We store the start position ourselves. This way we do no longer need to rely on the event sequence still being active when ending a drag operation.

### Does this PR introduce a breaking change?
- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information

It may be nicer to rewrite the move handlers to work with offsets, so the interface is in line with what we have in the controllers. However, that's considerably more work.
