### PR TITLE
Replace pr-labeler-action with actions/labeler

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,12 @@
+documentation:
+  - changed-files:
+      - any-glob-to-any-file: 'docs/*.md'
+      - any-glob-to-any-file: 'docs/*.rst'
+      - any-glob-to-any-file: '*.md'
+python:
+  - changed-files:
+      - any-glob-to-any-file: 'gaphas/**/*.py'
+skip-changelog:
+  - changed-files:
+      - any-glob-to-any-file: '.pre-commit-config.yaml'
+      - any-glob-to-any-file: '.all-contributorsrc'

--- a/.github/pr-labeler.yml
+++ b/.github/pr-labeler.yml
@@ -1,4 +1,0 @@
-feature: ['feature/*', 'feat/*']
-fix: fix/*
-chore: chore/*
-skip-changelog: ['sourcery/*', 'dependabot/*', 'pre-commit-ci-*']

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -1,7 +1,7 @@
-name: PR Labeler
+name: "Pull Request Labeler"
 on:
-  pull_request_target:
-    types: [opened]
+  # pull_request_target is not considered safe, but only updates PRs in our case.
+  - pull_request_target
 
 permissions:
   contents: read
@@ -9,19 +9,21 @@ permissions:
 jobs:
   pr-labeler:
     permissions:
-      pull-requests: write  # for TimonVS/pr-labeler-action to add labels in PR
+      contents: read
+      pull-requests: write
     runs-on: ubuntu-24.04
-    if: "!contains(github.event.head_commit.message, 'skip ci')"
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@0634a2670c59f64b4a01f0f96f84700a4088b9f0 # v2.12.0
         with:
+          disable-sudo: true
           egress-policy: block
           allowed-endpoints: >
             api.github.com:443
             *.githubusercontent.com:443
             ghcr.io
 
-      - uses: TimonVS/pr-labeler-action@f9c084306ce8b3f488a8f3ee1ccedc6da131d1af # v5.0.0
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # v5.0.0
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"
+          sync-labels: false


### PR DESCRIPTION
I noticed the [pr-labeler-action](https://github.com/TimonVS/pr-labeler-action) failed a CI run during a dependabot run. It is probably better for us to migrate to the official labeler action like Gaphor is using.

### PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I have read and I am following the [Contributor guide](https://github.com/gaphor/gaphas/blob/main/CONTRIBUTING.md)
- [X] I have read and I understand the [Code of Conduct](https://github.com/gaphor/gaphas/blob/main/CODE_OF_CONDUCT.md)

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [X] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes

### What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

### What is the new behavior?

### Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
